### PR TITLE
Allow loading package dependencies from @frompackage/@fromparent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [targets]
-test = ["Test", "Pluto", "Pkg", "Revise"]
+test = ["Test", "Pluto", "Pkg", "Revise", "BenchmarkTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,13 @@ HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 HypertextLiteral = "0.9"
 MacroTools = "0.5"
-Requires = "1"
 julia = "1.8"
 
 [extras]

--- a/src/PlutoDevMacros.jl
+++ b/src/PlutoDevMacros.jl
@@ -1,7 +1,6 @@
 module PlutoDevMacros
 
 using MacroTools
-using Requires
 using HypertextLiteral
 
 # export @only_in_nb, @only_out_nb, include_mapexpr, @skip_as_script

--- a/src/frompackage/FromPackage.jl
+++ b/src/frompackage/FromPackage.jl
@@ -1,5 +1,5 @@
 module FromPackage
-    import ..PlutoDevMacros: @addmethod
+    import ..PlutoDevMacros: @addmethod, _cell_data
     using HypertextLiteral
     export @fromparent, @addmethod, @frompackage
 

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -66,6 +66,14 @@ function simulate_manual_rerun(cell_ids::Array; kwargs...)
 	end
 end
 
+# Functions to add and remove from the LOAD_PATH
+function add_loadpath(entry::String)
+	length(LOAD_PATH) > 1 && LOAD_PATH[2] != entry && insert!(LOAD_PATH, 2, entry)
+end
+function clean_loadpath(entry::String)
+	LOAD_PATH[2] == entry && deleteat!(LOAD_PATH, 2)
+end
+
 ## execute only in notebook
 # We have to create our own simple check to only execute some stuff inside the notebook where they are defined. We have stuff in basics.jl but we don't want to include that in this notebook
 function is_notebook_local()

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -1,3 +1,22 @@
+# We define here the types to identify the imports
+abstract type ImportType end
+for name in (:FromParentImport, :FromPackageImport, :FromDepsImport, :RelativeImport)
+	expr = :(struct $name <: ImportType
+		mod_name::Symbol
+	end) 
+	eval(expr)
+end
+
+function import_type(first_name::Symbol, dict)
+	mod_name = Symbol(dict["name"])
+	first_name ∈ (:PackageModule, mod_name) && return FromPackageImport(mod_name)	
+	first_name === :. && return RelativeImport(mod_name)
+	first_name ∈ (:*, :ParentModule) && return FromParentImport(mod_name)
+	String(first_name) ∈ keys(dict["deps"]) && return FromDepsImport(mod_name)
+	# If we reach here we don't have a supported import type
+	error("The @frompackage/@fromparent macros only supports import statements that are either starting with `PackageModule`, `ParentModule`, `*` or expressing a reltive module path (starting with a dot)")
+end
+
 # Get the full path of the module as array of Symbols starting from Main
 function modname_path(m::Module)
 	args = [nameof(m)]
@@ -37,6 +56,10 @@ end
 target_found(dict) = haskey(dict, "Target Path")
 
 function valid_outside_pluto(ex)
+	# We could support FromDeps imports also outside Pluto, but that would
+	# require extracting the package dependencies also outside of Pluto, so we
+	# avoid that. This forces the user to specifically put using statements
+	# within the main module file as it is usually done
 	mod_name, imported_names = extract_import_args(ex)
 	mod_name.args[1] === :. || return false # We only support relative module names
 	contains_catchall(imported_names) && return false # We don't support the catchall outside import outside Pluto
@@ -81,35 +104,39 @@ function contains_catchall(modname, imported_names)
 	return import_catchall || modname_catchall
 end
 
-## process imported nameargs
+## process imported nameargs, generic version
 function process_imported_nameargs!(args, dict)
 	# We modify the module name expression to point to the current path within the _PackageModule_ that is loaded in Pluto
-	name_init = modname_path(fromparent_module[])
-	mod_name = Symbol(dict["name"])
 	first_name = args[1]
-	if first_name ∈ (:PackageModule, mod_name)
-		# We substitute the `PackageModule` with the actual name of the loaded package
-		args[1] = mod_name
-	elseif first_name ∈ (:., :*, :ParentModule)
-		# Here transform the relative module name to the one based on the full loaded module path
-		target_path = get(dict, "Target Path", []) |> reverse
-		isempty(target_path) && error("The current file was not found included in the loaded module $mod_name, so you can't use relative path imports")
-		# We pop the first argument which is either `:.` or `:*` since we are in this branch
-		popfirst!(args)
-		while getfirst(args) === :. 
-			# We pop the dot
-			popfirst!(args)
-			# We also pop the last part of the target path
-			pop!(target_path)
-		end
-		# We prepend the target_path to the args
-		prepend!(args, target_path)
-	else
-		error("The @frompackage/@fromparent macros only supports import statements that are either starting with `PackageModule`, `ParentModule`, `*` or expressing a reltive module path (starting with a dot)")
-	end
-	# We now add ._PackageModule
+	type = import_type(first_name, dict)
+	# We process the args based on the type and return them
+	process_imported_nameargs!(args, dict, type)
+	return args, type
+end
+## Per-type versions
+function process_imported_nameargs!(args, dict, t::FromPackageImport)
+	name_init = modname_path(fromparent_module[])
+	args[1] = t.mod_name
 	prepend!(args, name_init)
 end
+function process_imported_nameargs!(args, dict, t::Union{FromParentImport, RelativeImport})
+	mod_name = Symbol(dict["name"])
+	name_init = modname_path(fromparent_module[])
+	# Here transform the relative module name to the one based on the full loaded module path
+	target_path = get(dict, "Target Path", []) |> reverse
+	isempty(target_path) && error("The current file was not found included in the loaded module $(t.mod_name), so you can't use relative path imports")
+	# We pop the first argument which is either `:.`, `:FromParent` or `:*`
+	popfirst!(args)
+	while getfirst(args) === :. 
+		# We pop the dot
+		popfirst!(args)
+		# We also pop the last part of the target path
+		pop!(target_path)
+	end
+	# We prepend the target_path to the args
+	prepend!(args, name_init, target_path)
+end
+process_imported_nameargs!(args, dict, ::FromDepsImport) = args
 
 ## parseinput
 function parseinput(ex, dict)
@@ -117,10 +144,18 @@ function parseinput(ex, dict)
 	modname_expr, importednames_exprs = extract_import_args(ex)
 	# Check if we have a catchall
 	catchall = contains_catchall(ex)
-	# Check if the statement is a using or an import, this is used to check which names to eventually import, but all statements are converted into `import`
+	# Check if the statement is a using or an import, this is used to check
+	# which names to eventually import, but all statements are converted into
+	# `import` if they are not of type FromDepsImport
 	is_using = ex.head === :using 
+	args, type = process_imported_nameargs!(modname_expr.args, dict)
+	# Check that we don't catchall with imported dependencies
+	if catchall && type isa FromDepsImport
+		error("You can't use the catch-all name identifier (*) while importing dependencies of the Package Environment")
+	end
+	# In case we have simply a dependency improt, we maintain the expression
+	type isa FromDepsImport && return ex
 	ex.head = :import
-	args = process_imported_nameargs!(modname_expr.args, dict)
 	# If we don't have a catchall and we are either importing or using just specific names from the module, we can just return the modified expression
 	if !catchall && (!is_using || !isempty(importednames_exprs))
 		return ex

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -87,7 +87,7 @@ function process_imported_nameargs!(args, dict)
 	name_init = modname_path(fromparent_module[])
 	mod_name = Symbol(dict["name"])
 	first_name = args[1]
-	if first_name === :PackageModule
+	if first_name ∈ (:PackageModule, mod_name)
 		# We substitute the `PackageModule` with the actual name of the loaded package
 		args[1] = mod_name
 	elseif first_name ∈ (:., :*, :ParentModule)

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -14,8 +14,8 @@ function import_type(first_name::Symbol, dict)
 	first_name ∈ (:*, :ParentModule) && return FromParentImport(mod_name)
 	(;direct, indirect) = dict["PkgInfo"]
 	String(first_name) ∈ keys(direct) && return FromDepsImport(mod_name)
-	String(first_name) ∈ _stdlibs && return FromDepsImport(mod_name)
-	String(first_name) ∈ keys(indirect) && return FromDepsImport(mod_name)
+	# String(first_name) ∈ _stdlibs && return FromDepsImport(mod_name)
+	# String(first_name) ∈ keys(indirect) && return FromDepsImport(mod_name)
 	# If we reach here we don't have a supported import type
 	error("The provided import expression is not supported, please look at @frompackage documentation to see the supported imports")
 end
@@ -68,8 +68,8 @@ function valid_outside_pluto(ex, dict)
 	s = String(first_name)
 	(;direct, indirect) = dict["PkgInfo"]
 	s ∈ keys(direct) && return true
-	s ∈ _stdlibs && return true
-	s ∈ keys(indirect) && return true
+	# s ∈ _stdlibs && return true
+	# s ∈ keys(indirect) && return true
 	return false
 end
 

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -156,14 +156,15 @@ function parseinput(ex, dict)
 	# In case we have simply a dependency improt, we maintain the expression
 	type isa FromDepsImport && return ex
 	ex.head = :import
-	# If we don't have a catchall and we are either importing or using just specific names from the module, we can just return the modified expression
-	if !catchall && (!is_using || !isempty(importednames_exprs))
-		return ex
-	end
-	# In all other cases we need to access the specific imported module
+	# We try going towards the intended submodule, just to verify that in case
+	# of relative imports, the provided submodule name actually exists
 	_mod = Main
 	for field in args[2:end]
 		_mod = getfield(_mod, field)
+	end
+	# If we don't have a catchall and we are either importing or using just specific names from the module, we can just return the modified expression
+	if !catchall && (!is_using || !isempty(importednames_exprs))
+		return ex
 	end
 	# We extract the imported names either due to catchall or due to the standard using
 	imported_names = filterednames(_mod; all = catchall, imported = catchall)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -96,15 +96,6 @@ end
 function maybe_create_module(m::Module)
 	if !isassigned(fromparent_module) 
 		fromparent_module[] = Core.eval(m, :(module $(gensym(:frompackage)) 
-			# We import PlutoRunner in this module, or we just create a dummy module otherwise
-			PlutoRunner = let 
-				if isdefined(Main, :PlutoRunner)
-					Main.PlutoRunner
-				else
-					@eval baremodule PlutoRunner
-					end
-				end
-			end
 		end))
 	end
 	return fromparent_module[]

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -121,7 +121,7 @@ function load_module(target_file, calling_file, _module)
 	mod_name = mod_exp.args[2]
 	proj_file = Base.current_project(target_file)
 	# We inject the project in the LOAD_PATH if it is not present already
-	length(LOAD_PATH) > 1 && LOAD_PATH[2] != proj_file && insert!(LOAD_PATH, 2, proj_file)
+	add_loadpath(proj_file)
 	# We try evaluating the expression within the custom module
 	stop_reason = try
 		reason = eval_in_module(_MODULE_,Expr(:toplevel, LineNumberNode(1, Symbol(target_file)), mod_exp), package_dict)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -119,7 +119,9 @@ function load_module(target_file, calling_file, _module)
 	_MODULE_ = maybe_create_module(_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
-	insert!(LOAD_PATH, 2, package_dict["project"])
+	proj_file = Base.current_project(target_file)
+	# We inject the project in the LOAD_PATH if it is not present already
+	length(LOAD_PATH) > 1 && LOAD_PATH[2] != proj_file && insert!(LOAD_PATH, 2, proj_file)
 	# We try evaluating the expression within the custom module
 	stop_reason = try
 		reason = eval_in_module(_MODULE_,Expr(:toplevel, LineNumberNode(1, Symbol(target_file)), mod_exp), package_dict)
@@ -127,8 +129,6 @@ function load_module(target_file, calling_file, _module)
 	catch e
 		package_dict["Stopping Reason"] = StopEval("Loading Error")
 		rethrow(e)
-	finally
-		deleteat!(LOAD_PATH, 2)
 	end
 	# Get the moduleof the parent package
 	__module = getfield(_MODULE_, mod_name)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -5,7 +5,7 @@ end
 StopEval(reason::String) = StopEval(reason, LineNumberNode(0))
 
 # Function to clean the filepath from the Pluto cell delimiter if present
-cleanpath(path::String) = first(split(path, "#==#"))
+cleanpath(path::String) = first(split(path, "#==#")) |> abspath
 
 ## general
 function eval_in_module(_mod, line_and_ex, dict)
@@ -33,7 +33,7 @@ function eval_include_expr(_mod, loc, ex, dict)
 		filename_str
 	else
 		calling_dir = dirname(String(loc.file))
-		normpath(calling_dir, filename_str)
+		abspath(calling_dir, filename_str)
 	end
 	# We check whether the file to be included is the target put as input to the macro
 	if filepath == cleanpath(dict["target"]) 

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -196,7 +196,11 @@ of the module when importing it into the notebook.
 *`import Module1, Module2` are not supported. In case multiple imports are
 *needed, use multiple statements within a `begin...end` block.
 
-Here are the kind of import statements that are supported by the macro:
+The type of import statements that are supported by the macro are of 4 Types:
+- Relative Imports 
+- Imports from the Package module
+- Import from the Parent module (or submodule)
+- Direct dependency import.
 
 ### Relative Imports
 Relative imports are the ones where the module name starts with a dot (.). These
@@ -209,29 +213,51 @@ module requires loading and inspecting the full Package module and is thus only
 functional inside of Pluto. **This kind of statement is deleted when
 @frompackage is called outside of Pluto**.
 
-### `FromPackage` imports
-These are all the import statements that have the name `FromPackage` as the
-first identifier, e.g.: - `using FromPackage.SubModule` - `import FromPackage:
-varname` - `import FromPackage.SubModule.SubSubModule: *` These statements are
-processed by the macro and transformed so that `FromPackage` actually points to
+### Imports from Package module
+These are all the import statements that have the name `PackageModule` as the
+first identifier, e.g.: - `using PackageModule.SubModule` - `import PackageModule:
+varname` - `import PackageModule.SubModule.SubSubModule: *` These statements are
+processed by the macro and transformed so that `PackageModule` actually points to
 the module that was loaded by the macro.
 
-### `FromParent` imports
-These statements are similar to `FromPackage` ones, with two main difference:
+### Imports from Package module (or submodule)
+These statements are similar to the previous (imports from Package module) ones, with two main difference:
 - They only work if the `target` file is actually a file that is included in the
 loaded Package, giving an error otherwise
-- `FromParent` does not point to the loaded Package, but the module that
+- `ParentModule` does not point to the loaded Package, but the module that
 contains the line that calls `include(target)`. If `target`  is loaded from the
-Package main module, and not from one of its submodules, then `FromParent` wil
-point to the same module as `FromPackage`.
+Package main module, and not from one of its submodules, then `ParentModule` will
+point to the same module as `PackageModule`.
 
-### Catch-All
-The last supported statement is `import *`, which is equivalent to `import
-FromParent: *`. 
+#### Catch-All
+A special kind parent module import is the form:
+```julia
+import *
+```
+which is equivalent to `import FromParent: *`. 
 
 This tries to reproduce within the namespace of the calling notebook, the
 namespace that would be visible by the notebook file when it is loaded as part
 of the Package module outside of Pluto.
+
+### Imports from Direct dependencies
+
+All import statements whose first module identifier is a direct dependency of
+the loaded Package are also supported both inside and outside Pluto. These kind
+of statements can not be used in combination with the `catch-all` imported name
+(*).
+
+This feature is useful when trying to combine `@frompackage` with the integrated
+Pluto PkgManager. In this case, is preferable to keep in the Pluto notebook
+environment just the packages that are not also part of the loaded Package
+environment, and load the eventual packages that are also direct dependencies of
+the loaded Package directly from within the `@frompackage` `import_block`.
+
+Doing so minimizes the risk of having issues caused by versions collision
+between dependencies that are shared both by the notebook environment and the
+loaded Package environment. Combining the use of `@frompackage` with the Pluto
+PkgManager is a very experimental feature that comes with significant caveats.
+Please read the [related section](https://github.com/disberd/PlutoDevMacros.jl#use-of-fromparentfrompackage-with-pluto-pkgmanager) on the Package README
 
 
 ## Reload Button

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -84,6 +84,9 @@ function frompackage(ex, target_file, caller, _module; macroname)
 end
 
 function _combined(ex, target, calling_file, __module__; macroname)
+	# Enforce absolute path to handle different OSs
+	target = abspath(target)
+	calling_file = abspath(calling_file)
 	_, cell_id = _cell_data(calling_file)
 	proj_file = Base.current_project(target)
 	out = try

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -16,6 +16,20 @@ function is_call_unique(cell_id, _module)
 	end
 end
 
+function is_macroexpand(trace, cell_id)
+	for _ ∈ eachindex(trace)
+		# We go throught the stack until we find the call to :macroexpand
+		frame = popfirst!(trace)
+		frame.func == :macroexpand && break
+	end
+	caller_frame = popfirst!(trace)
+	file, id = _cell_data(String(caller_frame.file))
+	if id == cell_id
+		@info "@macroexpand call"
+		return true
+	end
+	return false
+end
 
 ## @frompackage
 
@@ -31,8 +45,6 @@ function frompackage(ex, target_file, caller, _module; macroname)
 		error("Multiple Calls: The $macroname is already present in cell with id $(macro_cell[]), you can only have one call-site per notebook")
 	end
 	args = []
-	# We put the cell id variable
-	push!(args, :($id_name = true))
 	# We extract the parse dict
 	ex_args = if Meta.isexpr(ex, [:import, :using])
 		[ex]
@@ -46,35 +58,51 @@ function frompackage(ex, target_file, caller, _module; macroname)
 		arg isa LineNumberNode && continue
 		push!(args, parseinput(arg, dict))
 	end
-	# We add the expression that cleans the load path 
 	proj_file = Base.current_project(target_file)
-	push!(out.args, :(LOAD_PATH[2] == $proj_file && deleteat!(LOAD_PATH, 2)))
-	# We add the html button
+	# We wrap the import expressions inside a try-catch, as those also correctly work from there.
+	# This also allow us to be able to catch the error in case something happens during loading and be able to gracefully clean the work space
 	text = "Reload $macroname"
-	push!(args, :($html_reload_button($cell_id; text = $text)))
-	out = Expr(:block, args...)
+	out = quote
+		# We put the cell id variable
+		$id_name = true
+		try
+			$(args...)
+			# We add the reload button as last expression so it's sent to the cell output
+			$html_reload_button($cell_id; text = $text)
+		catch e
+			# We also send the reload button as an @info log, so that we can use the cell output to format the error nicely
+			@info $html_reload_button($cell_id; text = $text)
+			rethrow()
+		finally
+			# We add the expression that cleans the load path 
+			$clean_loadpath($proj_file)
+		end
+	end
 	return out
 end
 
 function _combined(ex, target, calling_file, __module__; macroname)
-	try
+	_, cell_id = _cell_data(calling_file)
+	proj = Base.current_project(target)
+	out = try
 		frompackage(ex, target, calling_file, __module__; macroname)
 	catch e
 		bt = stacktrace(catch_backtrace())
 		out = Expr(:block)
 		if !(e isa ErrorException && startswith(e.msg, "Multiple Calls: The"))
-			cell_id = split(calling_file, "#==#")[2]
 			text = "Reload $macroname"
 			# We add a log to maintain the reload button
 			push!(out.args, :(@info $html_reload_button($cell_id; text = $text, err = true)))
 		end
 		# We have to also remove the project from the load path
-		proj = Base.current_project(target)
-		push!(out.args, :(LOAD_PATH[2] == $proj_file && deleteat!(LOAD_PATH, 2)))
+		clean_loadpath(proj)
 		# Outputting the CaptureException as last statement allows pretty printing of errors inside Pluto
 		push!(out.args,	:(CapturedException($e, $bt)))
 		out
 	end
+	# Check if we are inside a direct macroexpand code, and clean the LOAD_PATH if we do
+	is_macroexpand(stacktrace(), cell_id) && clean_loadpath(proj)
+	out
 end
 
 """

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -46,6 +46,9 @@ function frompackage(ex, target_file, caller, _module; macroname)
 		arg isa LineNumberNode && continue
 		push!(args, parseinput(arg, dict))
 	end
+	# We add the expression that cleans the load path 
+	proj_file = Base.current_project(target_file)
+	push!(out.args, :(LOAD_PATH[2] == $proj_file && deleteat!(LOAD_PATH, 2)))
 	# We add the html button
 	text = "Reload $macroname"
 	push!(args, :($html_reload_button($cell_id; text = $text)))
@@ -65,6 +68,10 @@ function _combined(ex, target, calling_file, __module__; macroname)
 			# We add a log to maintain the reload button
 			push!(out.args, :(@info $html_reload_button($cell_id; text = $text, err = true)))
 		end
+		# We have to also remove the project from the load path
+		proj = Base.current_project(target)
+		push!(out.args, :(LOAD_PATH[2] == $proj_file && deleteat!(LOAD_PATH, 2)))
+		# Outputting the CaptureException as last statement allows pretty printing of errors inside Pluto
 		push!(out.args,	:(CapturedException($e, $bt)))
 		out
 	end

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -22,6 +22,7 @@ function is_macroexpand(trace, cell_id)
 		frame = popfirst!(trace)
 		frame.func == :macroexpand && break
 	end
+	length(trace) < 1 && return false
 	caller_frame = popfirst!(trace)
 	file, id = _cell_data(String(caller_frame.file))
 	if id == cell_id
@@ -34,7 +35,7 @@ end
 ## @frompackage
 
 function frompackage(ex, target_file, caller, _module; macroname)
-	is_notebook_local(caller) || return process_outside_pluto!(ex)
+	is_notebook_local(caller) || return process_outside_pluto!(ex, get_package_data(target_file))
 	_, cell_id = _cell_data(caller)
 	proj_file = Base.current_project(target_file)
 	id_name = _id_name(cell_id)

--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.0-rc3"
 manifest_format = "2.0"
-project_hash = "8811b218d68574c29934b3939a69b3721d88f2a4"
+project_hash = "7d7d6675ed0eabff36944a4efaef2e483493113b"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -14,11 +14,22 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[deps.BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "d9a9701b899b30332bbcb3e1679c41cce81fb0e8"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.3.2"
+
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
 git-tree-sha1 = "d730914ef30a06732bdd9f763f6cc32e92ffbff1"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 version = "1.3.1"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.2+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -45,6 +56,12 @@ version = "0.9.4"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
@@ -74,6 +91,10 @@ version = "1.10.2+0"
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
@@ -98,6 +119,9 @@ deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+0"
 
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2022.10.11"
@@ -106,10 +130,21 @@ version = "2022.10.11"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.21+4"
+
 [[deps.OrderedCollections]]
 git-tree-sha1 = "d321bf2de576bf25ec4d3e4360faca399afca282"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.0"
+
+[[deps.Parsers]]
+deps = ["Dates", "SnoopPrecompile"]
+git-tree-sha1 = "478ac6c952fddd4399e71d4779797c538d0ff2bf"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.5.8"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -122,9 +157,19 @@ path = "../.."
 uuid = "a0499f29-c39b-4c5c-807c-88074221b949"
 version = "0.5.1"
 
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -153,8 +198,28 @@ version = "0.7.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[deps.SnoopPrecompile]]
+deps = ["Preferences"]
+git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
+uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+version = "1.0.3"
+
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.9.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "5.10.1+6"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -182,6 +247,11 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.13+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.7.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -77,12 +77,6 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[deps.LoggingExtras]]
-deps = ["Dates", "Logging"]
-git-tree-sha1 = "cedb76b37bc5a6c702ade66be44f831fa23c681e"
-uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-version = "1.0.0"
-
 [[deps.LoweredCodeUtils]]
 deps = ["JuliaInterpreter"]
 git-tree-sha1 = "60168780555f3e663c536500aa790b6368adc02a"
@@ -123,10 +117,10 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.9.0"
 
 [[deps.PlutoDevMacros]]
-deps = ["HypertextLiteral", "InteractiveUtils", "LoggingExtras", "MacroTools", "Markdown", "Random", "Requires", "TOML"]
+deps = ["HypertextLiteral", "InteractiveUtils", "MacroTools", "Markdown", "Pkg", "Random", "TOML"]
 path = "../.."
 uuid = "a0499f29-c39b-4c5c-807c-88074221b949"
-version = "0.5.0"
+version = "0.5.1"
 
 [[deps.Printf]]
 deps = ["Unicode"]

--- a/test/TestPackage/Project.toml
+++ b/test/TestPackage/Project.toml
@@ -4,6 +4,7 @@ authors = ["Alberto Mengali <disberd@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PlutoDevMacros = "a0499f29-c39b-4c5c-807c-88074221b949"

--- a/test/TestPackage/src/inner_notebook1.jl
+++ b/test/TestPackage/src/inner_notebook1.jl
@@ -20,7 +20,13 @@ end
 using PlutoDevMacros.FromPackage
 
 # ╔═╡ e1c8bbbd-da6f-4550-9f2c-30337d4962ad
-@fromparent import ..TestPackage: testmethod
+@fromparent begin
+	import ..TestPackage: testmethod
+	import BenchmarkTools # This is a direct dependency of the package
+end
+
+# ╔═╡ c83b0017-bb5e-48bd-96e6-5192b6151233
+BenchmarkTools isa Module
 
 # ╔═╡ c30c2104-9fb1-4afd-a119-6da9d50ae2b6
 testmethod(3)
@@ -38,6 +44,7 @@ testmethod(3)
 # ╠═f90b0ae3-0e16-4b83-8546-23d4450812b2
 # ╠═8aa0221b-8f13-4ee8-8cc6-a19fdce2468b
 # ╠═e1c8bbbd-da6f-4550-9f2c-30337d4962ad
+# ╠═c83b0017-bb5e-48bd-96e6-5192b6151233
 # ╠═c30c2104-9fb1-4afd-a119-6da9d50ae2b6
 # ╠═596410f6-81b7-48ae-a761-e5cca4a996ba
 # ╠═a1430424-c9b8-4517-9105-c4daa72fdeea

--- a/test/frompackage.jl
+++ b/test/frompackage.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module, modname_path, fromparent_module, parseinput
 
 using Test
 import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell, project_relative_path, SessionActions, load_notebook, Configuration
@@ -10,6 +10,8 @@ import TestPackage: testmethod
 import TestPackage.Issue2
 pop!(LOAD_PATH)
 
+
+
 function noerror(cell; verbose=true)
     if cell.errored && verbose
         @show cell.output.body
@@ -19,21 +21,13 @@ end
 
 @testset "FromPackage" begin
     @testset "Outside Pluto" begin
-        rmnothing(ex::Expr) = Expr(ex.head, filter(x -> x !== :nothing && !isnothing(x), ex.args)...)
-        rmnothing(x) = x
-        function expr_equal(ex1, ex2)
-            ex1 = prewalk(rmlines, deepcopy(ex1))
-            ex1 = postwalk(rmnothing, ex1)
-            ex2 = prewalk(rmlines, deepcopy(ex2))
-            ex2 = postwalk(rmnothing, ex2)
-            ex1 == ex2
-        end
-
         ex = :(import .ASD: lol)
         @test deepcopy(ex) == process_outside_pluto!(ex)
         ex = :(import .ASD: *)
         @test nothing === process_outside_pluto!(ex)
-        ex = :(import module: lol)
+        ex = :(import PlutoDevMacros: lol)
+        @test nothing === process_outside_pluto!(ex)
+        ex = :(import *)
         @test nothing === process_outside_pluto!(ex)
 
 
@@ -50,6 +44,85 @@ end
 
 
     @testset "Inside Pluto" begin
+        @testset "Input Parsing" begin
+            # We point at the helpers file inside the FromPackage submodule, we only load the constants in the Loaded submodule
+            target = "../src/frompackage/helpers.jl"
+            # We simulate a caller from a notebook by appending a fake cell-id
+            caller = join([ @__FILE__, "#==#", "00000000-0000-0000-0000-000000000000" ])
+            @testset "Target included in Package" begin
+                # We create here the dummy module of PlutoDevMacros as it would be loaded by @frompackage inside Pluto
+                dict = load_module(target, caller, Main)
+                f(ex) = parseinput(deepcopy(ex), dict)
+
+                parent_path = modname_path(fromparent_module[])
+                # FromDeps imports
+                ex = :(using MacroTools)
+                @test ex == f(ex) # This should work as MacroTools is a deps of PlutoDevMacros
+
+                ex = :(using MacroTools: *)
+                @test_throws "catch-all" f(ex) 
+
+                ex = :(using DataFrames)
+                @test_throws "only supports import" f(ex) 
+
+                # FromPackage imports
+                ex = :(import PlutoDevMacros)
+                expected = :(import $(parent_path...).PlutoDevMacros)
+                @test expected == f(ex) # This works because PlutoDevMacros is the name of the loaded package
+
+                ex = :(import PackageModule.Script)
+                expected = :(import $(parent_path...).PlutoDevMacros.Script)
+                @test expected == f(ex)
+
+                ex = :(using PackageModule.Script)
+                expected = :(import $(parent_path...).PlutoDevMacros.Script: HTLBypass, HTLScript, HTLScriptPart, Script, combine_scripts)
+                @test expected == f(ex)
+
+                # Relative imports
+                ex = :(import ..Script)
+                expected = :(import $(parent_path...).PlutoDevMacros.Script)
+                @test expected == f(ex) # This should work as Script is a valid sibling module of FromPackage
+
+                ex = :(import ..NonExistant)
+                @test_throws UndefVarError f(ex) # It can't find the module
+
+                # FromParent import
+                ex = :(import *)
+                expected = :(import $(parent_path...).PlutoDevMacros.FromPackage: @addmethod, @frompackage, @fromparent, FromPackage, _cell_data)
+                @test expected == f(ex)
+
+                ex = :(import ParentModule: *)
+                @test expected == f(ex)
+
+                ex = :(import ParentModule: _cell_data)
+                expected = :(import $(parent_path...).PlutoDevMacros.FromPackage: _cell_data)
+                @test expected == f(ex)
+
+                ex = :(using ParentModule)
+                expected = :(import $(parent_path...).PlutoDevMacros.FromPackage: @addmethod, @frompackage, @fromparent, FromPackage)
+                @test expected == f(ex)
+            end
+            @testset "Target not included in Package" begin
+                dict = load_module(caller, caller, Main)
+                f(ex) = parseinput(deepcopy(ex), dict)
+                parent_path = modname_path(fromparent_module[])
+
+                ex = :(import PackageModule.Script)
+                expected = :(import $(parent_path...).PlutoDevMacros.Script)
+                @test expected == f(ex)
+
+                # FromParent import
+                ex = :(import *)
+                @test_throws "The current file was not found" f(ex)
+
+                ex = :(import ParentModule: *)
+                @test_throws "The current file was not found" f(ex)
+
+                ex = :(import ParentModule: _cell_data)
+                @test_throws "The current file was not found" f(ex)
+            end
+        end
+
         options = Configuration.from_flat_kwargs(;disable_writing_notebook_files = true)
         srcdir = joinpath(@__DIR__, "TestPackage/src/")
         eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,4 @@
 using Test
 using PlutoDevMacros
-push!(LOAD_PATH, normpath(@__DIR__, "./TestPackage"))
-using TestPackage
-pop!(LOAD_PATH)
 
 include("frompackage.jl")


### PR DESCRIPTION
This PR adds functionality to @frompackage added in #6 that ease the combined use of Pluto PkgManager together with `@frompackage`/`@fromparent`.

# Added support for import statements with dependencies

The main additional feature is the possibility of loading direct dependency of the Package targeted by `@frompackage`.
This helps reducing the possibility of having problems with the same package loaded both by the notebook environment and by the package environment.

## LOAD_PATH management

To allow this, the removal of the package project from the `LOAD_PATH` is only done during evaluation of the expression returned by the macro, just after having performed all the import statements.

The returned expression now wraps the import inside a try-catch block to still be able to catch loading errors and correctly clean the load path and send the reload button code even after macro expansion.

## macroexpand support

The macro now recognize when its being called by macroexpand, and ensures that the load path is cleaned during the macro generation in that case (as the expression created by the macro that contains the LOAD_PATH cleanup is not evaluated)

## more tests

More tests have been added to check the expected transformation of the input expressions
