### PR TITLE
Update manifest loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,25 @@ While the points mentioned above are achievable within a single pluto notebook w
 
 To simply import other notebooks, `@ingredients` from [PlutoHooks](https://github.com/JuliaPluto/PlutoLinks.jl) or `@plutoinclude` (which is inspired from `@ingredients`) from this PlutoDevMacros already exist, but I found that they do have some limitations for what concerns directly using notebooks as building blocks for a package.
 
+### IMPORTANT NOTE
+As explained below, in the current implementation `@frompackage` only supports
+`target` files which are contained inside a Package Folder. Moreover, the
+package containing the `target` file must have a correctly resolved Manifest
+file. Make sure that the target Package is correctly resolved (i.e. by calling
+`Pkg.resolve` from the Package environment) in order to have `@frompackage` work
+properly
+
+### Arguments
+
 Here are more details on the two arguments expected by the macro
 
-### `target`
+#### target
 
-`target` has to be a String containing the path (either absolute or relative to the file calling the macro) that points to a local Package (the path can be to any file or subfolder within the Package folder) or to a specific file that is *included* in the Package (so the `target` file appears within the Package module definition inside an `include` call).
+The first argument `target` has to be a String containing the path (either absolute or relative to the file calling the macro) that points to a local Package (the path can be to any file or subfolder within the Package folder) or to a specific file that is *included* in the Package (so the `target` file appears within the Package module definition inside an `include` call).
 - When `target` is not pointing directly to a file included in the Package, the full code of the module defining the Package will be parsed and loaded in the Pluto workspace of the notebook calling the macro.
 - When `target` is actually a file included inside the Package. The macro will just parse the Package module code up to and excluding the inclusion of `target` and discard the rest of the code, thus loading inside Pluto just a reduced part of the package. This is mimicking the behavior of `include` within a package, such that each `included` file only has visibility on the code that was loaded _before_ its inclusion. This behavior is also essential when using this macro from a notebook that is also included in the target Package, to avoid problems with variable redefinitions within the Pluto notebook (this is also the original usecase of the macro).
 
-### `import_block` 
+#### `import_block` 
 
 The second argument to the macro is supposed to be either a single using/import statement, or multiple using/import statements wrapped inside a `begin...end` block.
 
@@ -34,6 +44,8 @@ These statements are used to conveniently select which of the loaded Package nam
 Most of these import statements are only relevant when called within Pluto, so `@frompackage` simply avoid loading the target Package and deletes these import statements **in most cases** when called oustide of Pluto. There is a specific type of import statement (relative import) that is relevant and applicable also outside of Pluto, so this kind of statement is maintained in the macro output even outside of Pluto.
 
 The macro respects the differentiation between `using` and `import` as in normal Julia, so statements containing `using Module` without any variable name specifier will import all the exported names of `Module`.
+
+### Supported using/import statements
 
 All supported statements also allow the following (catch-all) notation `import Module: *`, which imports within the notebook all the variables that are created or imported within `Module`. This is useful when one wants to avoid having either export everything from the module file directly, or specify all the names of the module when importing it into the notebook.
 

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -149,6 +149,14 @@ To simply import other notebooks, `@ingredients` from
 but I found that they do have some limitations for what concerns directly using
 notebooks as building blocks for a package.
 
+# IMPORTANT NOTE
+As explained below, in the current implementation `@frompackage` only supports
+`target` files which are contained inside a Package Folder. Moreover, the
+package containing the `target` file must have a correctly resolved Manifest
+file. Make sure that the target Package is correctly resolved (i.e. by calling
+`Pkg.resolve` from the Package environment) in order to have `@frompackage` work
+properly
+
 # Arguments
 Here are more details on the two arguments expected by the macro
 
@@ -189,6 +197,8 @@ The macro respects the differentiation between `using` and `import` as in normal
 Julia, so statements containing `using Module` without any variable name
 specifier will import all the exported names of `Module`.
 
+# Supported using/import statements
+
 All supported statements also allow the following (catch-all) notation `import
 Module: *`, which imports within the notebook all the variables that are created
 or imported within `Module`. This is useful when one wants to avoid having
@@ -205,7 +215,7 @@ The type of import statements that are supported by the macro are of 4 Types:
 - Import from the Parent module (or submodule)
 - Direct dependency import.
 
-### Relative Imports
+## Relative Imports
 Relative imports are the ones where the module name starts with a dot (.). These
 are mostly relevant when the loaded module contains multiple submodules and they
 are **the only supported statement that is kept also outside of Pluto**.
@@ -216,7 +226,7 @@ module requires loading and inspecting the full Package module and is thus only
 functional inside of Pluto. **This kind of statement is deleted when
 @frompackage is called outside of Pluto**.
 
-### Imports from Package module
+## Imports from Package module
 These are all the import statements that have the name `PackageModule` as the
 first identifier, e.g.: - `using PackageModule.SubModule` - `import PackageModule:
 varname` - `import PackageModule.SubModule.SubSubModule: *` These statements are
@@ -231,7 +241,7 @@ As alternative, `^` can also be used to represent the `PackageModule`, so one ca
 This is to avoid triggering the Pkg statusmark within Pluto which always appears when a valid name of a package is typed (`^` is not valid so it doesn't create the status mark). See image below:
 ![image](https://user-images.githubusercontent.com/12846528/236888015-454183e6-44c1-4cd0-b9f8-9faf67aa0da6.png)
 
-### Imports from Parent module (or submodule)
+## Imports from Parent module (or submodule)
 These statements are similar to the previous (imports from Package module) ones, with two main difference:
 - They only work if the `target` file is actually a file that is included in the
 loaded Package, giving an error otherwise
@@ -240,7 +250,7 @@ contains the line that calls `include(target)`. If `target`  is loaded from the
 Package main module, and not from one of its submodules, then `ParentModule` will
 point to the same module as `PackageModule`.
 
-#### Catch-All
+### Catch-All
 A special kind parent module import is the form:
 ```julia
 import *
@@ -251,7 +261,7 @@ This tries to reproduce within the namespace of the calling notebook, the
 namespace that would be visible by the notebook file when it is loaded as part
 of the Package module outside of Pluto.
 
-### Imports from Direct dependencies
+## Imports from Direct dependencies
 
 It is possible to to import direct dependencie of the target Package from within the `@frompackage` macro. To do so, one must prepend the package name with `>.`, so for example if one wants to load the `BenchmarkTools` package from the macro, assuming that it is indeed a direct dependency of the target package, one can do:
 ```julia
@@ -283,7 +293,7 @@ PkgManager is a very experimental feature that comes with significant caveats.
 Please read the [related section](#use-of-fromparentfrompackage-with-pluto-pkgmanager) at the end of this README
 
 
-## Skipping Package Parts
+# Skipping Package Parts
 The macro also allows to specify parts of the source code of the target Package that have to be skipped when loading it within Pluto. This is achieved by adding a statement inside the `import_block` like the following:
 ```julia
 @skiplines lines
@@ -303,7 +313,7 @@ In all of the examples above `filepath` can be provided as either an absolute pa
 The functionality of skipping lines is only used when `@frompackage` is called inside Pluto. 
 When calling the macro from outside of Pluto, the eventual statement with `@skiplines` is discarded.
 
-### Example
+## Example
 
 For an example consider the source file of the `TestPackage.jl` defined within the test subfolder with the contents shown below:
 ![image](https://user-images.githubusercontent.com/12846528/236829189-dc30414a-d936-4a63-831b-963664249558.png)
@@ -325,7 +335,7 @@ The output of the notebook is also pasted here for reference:
 ![image](https://user-images.githubusercontent.com/12846528/236832303-eb2fdc0f-08fd-47e7-9c1d-35f1f1b637fd.png)
 
 
-## Reload Button
+# Reload Button
 The macro, when called within Pluto, also creates a convenient button that can
 be used to re-execute the cell calling the macro to reloade the Package code due
 to a change. It can also be used to quickly navigate to the position of the cell


### PR DESCRIPTION
Move away from Base function to extract the manifest file as it performs internal caching of previous results.

Add a custom error for when a Manifest file is not found and add tests for some of the custom errors.

README and docstrings updated to highlight the need of using a file contained in a properly resolved Package as `target` for the macro