### PR TITLE
Revert to using project dependencies when Manifest is not found

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         version:
           - '1.8'
-          - '~1.9.0-0'
+          - '1.9'
         os:
           - ubuntu-latest
           - windows-latest

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -96,6 +96,8 @@ function _combined(ex, target, calling_file, __module__; macroname)
 	out = try
 		frompackage(ex, target, calling_file, __module__; macroname)
 	catch e
+		# If we are outside of pluto we simply rethrow
+		is_notebook_local(calling_file) || rethrow()
 		bt = stacktrace(catch_backtrace())
 		out = Expr(:block)
 		if !(e isa ErrorException && startswith(e.msg, "Multiple Calls: The"))

--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.0-rc3"
+julia_version = "1.9.0"
 manifest_format = "2.0"
 project_hash = "312792d949ca909f2f223c32651672a933fb0970"
 
@@ -141,10 +141,10 @@ uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.0"
 
 [[deps.Parsers]]
-deps = ["Dates", "SnoopPrecompile"]
-git-tree-sha1 = "478ac6c952fddd4399e71d4779797c538d0ff2bf"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "a5aef8d4a6e8d81f171b2bd4be5265b01384c74c"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.5.8"
+version = "2.5.10"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -155,7 +155,13 @@ version = "1.9.0"
 deps = ["HypertextLiteral", "InteractiveUtils", "MacroTools", "Markdown", "Pkg", "Random", "TOML"]
 path = "../.."
 uuid = "a0499f29-c39b-4c5c-807c-88074221b949"
-version = "0.5.2"
+version = "0.5.4"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "259e206946c293698122f63e2b513a7c99a244e8"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -197,12 +203,6 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[deps.SnoopPrecompile]]
-deps = ["Preferences"]
-git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
-uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-version = "1.0.3"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -18,14 +18,6 @@ outpluto_caller = abspath(@__DIR__,"../..")
 inpluto_caller = join([outpluto_caller, "#==#", "00000000-0000-0000-0000-000000000000"])
 
 @testset "Errors" begin
-    # Test that we give a meaningful error when Manifest is not found
-    @test_throws "Manifest" mktempdir() do tmpdir
-        cd(tmpdir) do 
-            Pkg.generate("Manifest")
-            package_dependencies("Manifest")
-        end
-    end
-
     @test_throws "No parent project" mktempdir() do tmpdir
             package_dependencies(tmpdir)
     end

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -17,8 +17,6 @@ options = Configuration.from_flat_kwargs(; disable_writing_notebook_files=true)
 srcdir = joinpath(@__DIR__, "../TestPackage/src/")
 eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)
 
-@info "Check Load" TestPackage, typeof(TestPackage)
-
 @testset "notebook1.jl" begin
     ss = ServerSession(; options)
     path = joinpath(srcdir, "notebook1.jl")

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -17,6 +17,8 @@ options = Configuration.from_flat_kwargs(; disable_writing_notebook_files=true)
 srcdir = joinpath(@__DIR__, "../TestPackage/src/")
 eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)
 
+@info "Check Load" TestPackage, typeof(TestPackage)
+
 @testset "notebook1.jl" begin
     ss = ServerSession(; options)
     path = joinpath(srcdir, "notebook1.jl")


### PR DESCRIPTION
This PR changes the way package dependencies are extracted.

Before the manifest was used to extract package information and an error was thrown when a Manifest file was not found. This was made to ensure that the user only targeted packages with an instantiated environment when using `@frompackage`, but it broke nested loading of packages using `@frompackage` (see #14).

Additionally, whenever an error is raised while expanding the macro outside of Pluto, the error is immediately rethrown in the try-catch block to avoid generating and logging the HTML for the reload button (see #13)

should fix #13 and #14