### PR TITLE
Improve Extensions handling (Partial interal overhaul)

### DIFF
--- a/src/frompackage/FromPackage.jl
+++ b/src/frompackage/FromPackage.jl
@@ -1,9 +1,11 @@
 module FromPackage
     import ..PlutoDevMacros: @addmethod, _cell_data
     using HypertextLiteral
+    import Pkg
+    import Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest
     export @fromparent, @addmethod, @frompackage
 
-
+    include("types.jl")
     include("helpers.jl")
     include("code_parsing.jl")
     include("loading.jl")

--- a/src/frompackage/FromPackage.jl
+++ b/src/frompackage/FromPackage.jl
@@ -9,4 +9,7 @@ module FromPackage
     include("loading.jl")
     include("input_parsing.jl")
     include("macro.jl")
+
+    # Here we will store modules from Base.loaded_modules that are explicitly requested inside `@frompackage` or that are needed to load extensions of the `@frompackage` target
+    module LoadedModules end
 end

--- a/src/frompackage/FromPackage.jl
+++ b/src/frompackage/FromPackage.jl
@@ -1,8 +1,6 @@
 module FromPackage
     import ..PlutoDevMacros: @addmethod, _cell_data
     using HypertextLiteral
-    import Pkg
-    import Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest
     export @fromparent, @addmethod, @frompackage
 
     include("types.jl")

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -54,6 +54,11 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 	active_manifest = active |> get_manifest_file
 	active_project = active |> get_project_file
 	target_manifest = get_target(ecg) |> get_manifest_file
+	if !isfile(target_manifest)
+		@info "It seems that the target package does not have a manifest file. Trying to instantiate its environment"
+		c.env = ecg.target
+        Pkg.instantiate(c)
+	end
 	if !isfile(active_manifest) || !isfile(active_project)
 		force = true
 	end

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -116,11 +116,14 @@ end
 # Get the full path of the module as array of Symbols starting from Main
 function modname_path(m::Module)
 	args = [nameof(m)]
+	m_old = m
 	_m = parentmodule(m)
-	while _m !== Main
+	while _m !== m_old && _m !== Main
+		m_old = _m
 		pushfirst!(args, nameof(_m))
 		_m = parentmodule(_m)
 	end
+	_m === Main || error("modname_path did not reach Main, this is not expected")
 	pushfirst!(args, nameof(_m))
 	return args
 end

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -127,12 +127,12 @@ function load_module_in_caller(package_dict::Dict, caller_module)
 end
 function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	target_file = package_dict["target"]
-	ecg = package_dict["ecg"]
+	ecg = ENVS
 	# If the module Reference inside fromparent_module is not assigned, we create the module in the calling workspace and assign it
 	_MODULE_ = maybe_create_module(caller_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
-	proj_file = active_project(ecg)
+	proj_file = ecg |> get_active |> get_project_file
 	# We inject the project in the LOAD_PATH if it is not present already
 	add_loadpath(proj_file)
 	# We try evaluating the expression within the custom module
@@ -170,7 +170,7 @@ function load_package_extensions(package_dict::Dict, caller_module::Module)
 	load_package_extensions(package_module, package_dict, caller_module)
 end
 function load_package_extensions(package_module::Module, package_dict::Dict, caller_module::Module)
-	add_loadpath(package_dict)
+	add_loadpath(ENVS)
 	# We try to reload 
 	try
 		maybe_add_extensions!(package_module, package_dict, caller_module)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -127,11 +127,12 @@ function load_module_in_caller(package_dict::Dict, caller_module)
 end
 function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	target_file = package_dict["target"]
+	ecg = package_dict["ecg"]
 	# If the module Reference inside fromparent_module is not assigned, we create the module in the calling workspace and assign it
 	_MODULE_ = maybe_create_module(caller_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
-	proj_file = Base.current_project(target_file)
+	proj_file = active_project(ecg)
 	# We inject the project in the LOAD_PATH if it is not present already
 	add_loadpath(proj_file)
 	# We try evaluating the expression within the custom module
@@ -175,8 +176,6 @@ function load_package_extensions(package_module::Module, package_dict::Dict, cal
 		maybe_add_extensions!(package_module, package_dict, caller_module)
 	catch
 		rethrow()
-	finally
-		clean_loadpath(package_dict)
 	end
 	nothing
 end

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -49,7 +49,7 @@ end
 function frompackage(ex, target_file, caller, caller_module; macroname)
 	is_notebook_local(caller) || return process_outside_pluto!(ex, get_package_data(target_file))
 	_, cell_id = _cell_data(caller)
-	maybe_update_envcache(Base.active_project(); notebook = true)
+	maybe_update_envcache(Base.active_project(), ENVS; notebook = true)
 	proj_file = Base.current_project(target_file)
 	id_name = _id_name(cell_id)
 	ex isa Expr || error("You have to call this macro with an import statement or a begin-end block of import statements")

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -49,7 +49,7 @@ end
 function frompackage(ex, target_file, caller, caller_module; macroname)
 	is_notebook_local(caller) || return process_outside_pluto!(ex, get_package_data(target_file))
 	_, cell_id = _cell_data(caller)
-	maybe_update_envcache(Base.active_project(), ENVS; notebook = true)
+	maybe_update_envcache(Base.active_project(), default_ecg(); notebook = true)
 	proj_file = Base.current_project(target_file)
 	id_name = _id_name(cell_id)
 	ex isa Expr || error("You have to call this macro with an import statement or a begin-end block of import statements")

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -49,6 +49,7 @@ end
 function frompackage(ex, target_file, caller, caller_module; macroname)
 	is_notebook_local(caller) || return process_outside_pluto!(ex, get_package_data(target_file))
 	_, cell_id = _cell_data(caller)
+	maybe_update_envcache(Base.active_project(); notebook = true)
 	proj_file = Base.current_project(target_file)
 	id_name = _id_name(cell_id)
 	ex isa Expr || error("You have to call this macro with an import statement or a begin-end block of import statements")
@@ -93,9 +94,6 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 			# We also send the reload button as an @info log, so that we can use the cell output to format the error nicely
 			@info $html_reload_button($cell_id; text = $text)
 			rethrow()
-		finally
-			# We add the expression that cleans the load path 
-			$clean_loadpath($proj_file)
 		end
 	end
 	return out
@@ -118,8 +116,6 @@ function _combined(ex, target, calling_file, caller_module; macroname)
 			# We send a log to maintain the reload button
 			@info html_reload_button(cell_id; text, err = true)
 		end
-		# We have to also remove the project from the load path
-		clean_loadpath(proj_file)
 		# Wrap ParseError in LoadError (see https://github.com/disberd/PlutoDevMacros.jl/issues/30)
 		we = wrap_parse_error(e)
 		# If we are at macroexpand, simply rethrow here, ohterwise output the expression with the error

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -1,3 +1,6 @@
+import Pkg
+import Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest
+
 const _stdlibs = first.(values(Pkg.Types.stdlibs()))
 
 const fromparent_module = Ref{Module}()

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -16,9 +16,9 @@ end
 const ENVS = EnvCacheGroup()
 
 struct PkgInfo 
-	name::String
-	uuid::String
-	version::String
+	name::Union{Nothing, String}
+	uuid::Base.UUID
+	version::Union{Nothing, VersionNumber}
 end
 
 # LineNumberRange. This are used for skipping parts of the target package

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -1,0 +1,49 @@
+const _stdlibs = first.(values(Pkg.Types.stdlibs()))
+
+const fromparent_module = Ref{Module}()
+const macro_cell = Ref("undefined")
+const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
+
+@kwdef mutable struct EnvCacheGroup
+    "This is the EnvCache of the environment added by @fromparent to the LOAD_PATH"
+    active::EnvCache = EnvCache(mktempdir())
+    "This is the environment of the target of @fromparent"
+    target::Union{Nothing, EnvCache} = nothing
+    "This is the environment of the notebook calling @fromparent"
+    notebook::Union{Nothing, EnvCache} = nothing
+end
+
+const ENVS = EnvCacheGroup()
+
+struct PkgInfo 
+	name::String
+	uuid::String
+	version::String
+end
+
+# LineNumberRange. This are used for skipping parts of the target package
+struct LineNumberRange
+	first::LineNumberNode
+	last::LineNumberNode
+	function LineNumberRange(ln1::LineNumberNode, ln2::LineNumberNode)
+		@assert ln1.file === ln2.file "A range of LineNumbers can only be specified with LineNumbers from the same file"
+		first, last = ln1.line <= ln2.line ? (ln1, ln2) : (ln2, ln1)
+		new(first, last)
+	end
+end
+LineNumberRange(ln::LineNumberNode) = LineNumberRange(ln, ln)
+LineNumberRange(file::AbstractString, first::Int, last::Int) = LineNumberRange(
+	LineNumberNode(first, Symbol(file)),
+	LineNumberNode(last, Symbol(file))
+)
+## Inclusion in LinuNumberRange
+function _inrange(ln::LineNumberNode, lnr::LineNumberRange)
+	ln.file === lnr.first.file || return false # The file is not the same
+	if ln.line >= lnr.first.line && ln.line <= lnr.last.line
+		return true
+	else
+		return false
+	end
+end
+_inrange(ln::LineNumberNode, ln2::LineNumberNode) = ln === ln2
+

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -16,7 +16,13 @@ const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
     notebook::Union{Nothing, EnvCache} = nothing
 end
 
-const ENVS = EnvCacheGroup()
+const DEFAULT_ECG = Ref{EnvCacheGroup}()
+function default_ecg()
+	if !isassigned(DEFAULT_ECG)
+		DEFAULT_ECG[] = EnvCacheGroup()
+	end
+	return DEFAULT_ECG[]
+end
 
 struct PkgInfo 
 	name::Union{Nothing, String}

--- a/test/TestDirectExtension/Project.toml
+++ b/test/TestDirectExtension/Project.toml
@@ -4,12 +4,13 @@ authors = ["Alberto Mengali <disberd@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+PlotlyExtensionsHelper = "a7e57fc7-3548-4021-90c3-ac0e175068b1"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [weakdeps]
-PlutoPlotly = "8e989ff0-3d88-8e9f-f020-2b208a939ff0"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 
 [extensions]
-PlutoPlotlyExt = "PlutoPlotly"
 Magic = "Example"
+PlotlyBaseExt = "PlotlyBase"

--- a/test/TestDirectExtension/Project.toml
+++ b/test/TestDirectExtension/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 PlotlyExtensionsHelper = "a7e57fc7-3548-4021-90c3-ac0e175068b1"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [weakdeps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/test/TestDirectExtension/ext/PlotlyBaseExt.jl
+++ b/test/TestDirectExtension/ext/PlotlyBaseExt.jl
@@ -1,0 +1,8 @@
+module PlotlyBaseExt
+    using PlotlyBase
+    using PlotlyExtensionsHelper
+    using TestDirectExtension
+
+    TestDirectExtension.to_extend(p::Plot) = "Standard Extension works!"
+    TestDirectExtension.plot_this() = plotly_plot(rand(10,4))
+end

--- a/test/TestDirectExtension/ext/PlutoPlotlyExt.jl
+++ b/test/TestDirectExtension/ext/PlutoPlotlyExt.jl
@@ -1,6 +1,0 @@
-module PlutoPlotlyExt
-    using PlutoPlotly
-    using TestDirectExtension
-
-    TestDirectExtension.to_extend(p::PlutoPlot) = "Standard Extension works!"
-end

--- a/test/TestDirectExtension/src/TestDirectExtension.jl
+++ b/test/TestDirectExtension/src/TestDirectExtension.jl
@@ -1,7 +1,8 @@
 module TestDirectExtension
 
-export to_extend
+export to_extend, plot_this
 
 to_extend(x) = "Generic Method"
+function plot_this end
 
 end # module TestDirectExtension

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -1,37 +1,21 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.19.39
 
 using Markdown
 using InteractiveUtils
-
-# ╔═╡ f6bb9eb6-1f66-424a-9043-607aeee0cd76
-begin
-	parent_project = Base.current_project(@__FILE__)
-	notebook_project = Base.active_project()
-	plutodevmacros_project= Base.current_project(normpath(@__DIR__, "../..")) 
-	Base.eval(Main, quote # instantiate the parent env, mostly for CI
-		import Pkg
-		Pkg.activate($parent_project)
-		Pkg.instantiate()
-		Pkg.activate($notebook_project)
-	end)
-	pushfirst!(LOAD_PATH, parent_project) # This contains Revise
-	pushfirst!(LOAD_PATH, plutodevmacros_project) # This loads the PlutoDevMacros environment, so we can do import with the latest version
-	try
-		Base.eval(Main, :(import Revise))
-		Base.eval(Main, :(import PlutoDevMacros))
-	finally
-		popfirst!(LOAD_PATH) # Remove plutodevmacros env
-		popfirst!(LOAD_PATH) # Remove parent_env
-	end
-	using Main.Revise
-	using Main.PlutoDevMacros
-end
 
 # ╔═╡ abccfc80-afaf-4c54-b300-c0c893de3848
 begin
 	using PlutoPlotly
 	using Example
+end
+
+# ╔═╡ f6bb9eb6-1f66-424a-9043-607aeee0cd76
+import PlutoDevMacros: @frompackage as @fp
+
+# ╔═╡ a5237419-a9e2-4b0c-83e6-4eb1907bb1be
+@fp "../.." begin
+	using ^.FromPackage
 end
 
 # ╔═╡ b93cdd74-1c65-4d15-a6e3-6c1855e37cce
@@ -45,27 +29,20 @@ standard_extension_output = to_extend(plot(rand(4)).Plot)
 # ╔═╡ 8e7563ce-d2ba-4356-93e4-70ebe0f2be87
 weird_extension_output = to_extend(Example)
 
-# ╔═╡ 25b8a9d0-d790-4b18-854d-4392291db823
-getproperty(TestDirectExtension, :plot_this)
-
-# ╔═╡ 3c8d1e3c-f081-4b73-82ab-e0a9b3958c92
-TestDirectExtension.plot_this
-
 # ╔═╡ da703251-1f4a-4fa1-ba08-720bceb2ada6
-# ╠═╡ disabled = true
-#=╠═╡
 p = plot_this()
-  ╠═╡ =#
 
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """
 [deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+PlutoDevMacros = "a0499f29-c39b-4c5c-807c-88074221b949"
 PlutoPlotly = "8e989ff0-3d88-8e9f-f020-2b208a939ff0"
 
 [compat]
 Example = "~0.5.3"
-PlutoPlotly = "~0.3.9"
+PlutoDevMacros = "~0.6.0"
+PlutoPlotly = "~0.4.4"
 """
 
 # ╔═╡ 00000000-0000-0000-0000-000000000002
@@ -74,7 +51,7 @@ PLUTO_MANIFEST_TOML_CONTENTS = """
 
 julia_version = "1.10.1"
 manifest_format = "2.0"
-project_hash = "d71ceab842b685ad63f73720ca026030946780f6"
+project_hash = "45c2663b0b08aa011df96ad7e600bf23da33df7e"
 
 [[deps.AbstractPlutoDingetjes]]
 deps = ["Pkg"]
@@ -91,6 +68,11 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BaseDirs]]
+git-tree-sha1 = "3e93fcd95fe8db4704e98dbda14453a0bfc6f6c3"
+uuid = "18cc8868-cbac-4acf-b575-c8ff214dc66f"
+version = "1.2.3"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
@@ -162,23 +144,11 @@ git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
-[[deps.Hyperscript]]
-deps = ["Test"]
-git-tree-sha1 = "179267cfa5e712760cd43dcae385d7ea90cc25a4"
-uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
-version = "0.0.5"
-
 [[deps.HypertextLiteral]]
 deps = ["Tricks"]
 git-tree-sha1 = "7134810b1afce04bbc1045ca1985fbe81ce17653"
 uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 version = "0.9.5"
-
-[[deps.IOCapture]]
-deps = ["Logging", "Random"]
-git-tree-sha1 = "8b72179abc660bfab5e28472e019392b97d0985c"
-uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.4"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -229,10 +199,11 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[deps.MIMEs]]
-git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
-uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
-version = "0.1.4"
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "2fa9ee3e63fd3a4f7a9a4f4744a52f4856de82df"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.13"
 
 [[deps.Markdown]]
 deps = ["Base64"]
@@ -264,12 +235,6 @@ git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.3"
 
-[[deps.PackageExtensionCompat]]
-git-tree-sha1 = "fb28e33b8a95c4cee25ce296c817d89cc2e53518"
-uuid = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-version = "1.0.2"
-weakdeps = ["Requires", "TOML"]
-
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
 git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
@@ -293,23 +258,25 @@ git-tree-sha1 = "56baf69781fc5e61607c3e46227ab17f7040ffa2"
 uuid = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 version = "0.8.19"
 
+[[deps.PlutoDevMacros]]
+deps = ["AbstractPlutoDingetjes", "DocStringExtensions", "HypertextLiteral", "InteractiveUtils", "MacroTools", "Markdown", "Pkg", "Random", "TOML"]
+git-tree-sha1 = "06fa4aa7a8f2239eec99cf54eeddd34f3d4359be"
+uuid = "a0499f29-c39b-4c5c-807c-88074221b949"
+version = "0.6.0"
+
 [[deps.PlutoPlotly]]
-deps = ["AbstractPlutoDingetjes", "Colors", "Dates", "HypertextLiteral", "InteractiveUtils", "LaTeXStrings", "Markdown", "PackageExtensionCompat", "PlotlyBase", "PlutoUI", "Reexport"]
-git-tree-sha1 = "9a77654cdb96e8c8a0f1e56a053235a739d453fe"
+deps = ["AbstractPlutoDingetjes", "BaseDirs", "Colors", "Dates", "Downloads", "HypertextLiteral", "InteractiveUtils", "LaTeXStrings", "Markdown", "Pkg", "PlotlyBase", "Reexport", "TOML"]
+git-tree-sha1 = "58dcb661ba1e58a13c7adce77435c3c6ac530ef9"
 uuid = "8e989ff0-3d88-8e9f-f020-2b208a939ff0"
-version = "0.3.9"
+version = "0.4.4"
 
     [deps.PlutoPlotly.extensions]
     PlotlyKaleidoExt = "PlotlyKaleido"
+    UnitfulExt = "Unitful"
 
     [deps.PlutoPlotly.weakdeps]
     PlotlyKaleido = "f2990250-8cf9-495f-b13a-cce12b45703c"
-
-[[deps.PlutoUI]]
-deps = ["AbstractPlutoDingetjes", "Base64", "ColorTypes", "Dates", "FixedPointNumbers", "Hyperscript", "HypertextLiteral", "IOCapture", "InteractiveUtils", "JSON", "Logging", "MIMEs", "Markdown", "Random", "Reexport", "URIs", "UUIDs"]
-git-tree-sha1 = "a6783c887ca59ce7e97ed630b74ca1f10aefb74d"
-uuid = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
-version = "0.7.57"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
@@ -387,19 +354,10 @@ git-tree-sha1 = "1feb45f88d133a655e001435632f019a9a1bcdb6"
 uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 version = "0.1.1"
 
-[[deps.Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 [[deps.Tricks]]
 git-tree-sha1 = "eae1bb484cd63b36999ee58be2de6c178105112f"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 version = "0.1.8"
-
-[[deps.URIs]]
-git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.5.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -436,12 +394,11 @@ version = "17.4.0+2"
 
 # ╔═╡ Cell order:
 # ╠═f6bb9eb6-1f66-424a-9043-607aeee0cd76
+# ╠═a5237419-a9e2-4b0c-83e6-4eb1907bb1be
 # ╠═abccfc80-afaf-4c54-b300-c0c893de3848
 # ╠═b93cdd74-1c65-4d15-a6e3-6c1855e37cce
 # ╠═675230da-e628-4059-b44d-6137a4dd4987
 # ╠═8e7563ce-d2ba-4356-93e4-70ebe0f2be87
-# ╠═25b8a9d0-d790-4b18-854d-4392291db823
-# ╠═3c8d1e3c-f081-4b73-82ab-e0a9b3958c92
 # ╠═da703251-1f4a-4fa1-ba08-720bceb2ada6
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -39,17 +39,23 @@ end
 	using PackageModule
 end
 
-# ╔═╡ 6721d53c-f94d-45ec-ad4e-be5e186fc58f
-PlutoDevMacros.FromPackage.getfirst
-
-# ╔═╡ d456f788-244a-4be6-91dc-0c64ecdca071
-PlutoDevMacros.FromPackage.bare_project
-
 # ╔═╡ 675230da-e628-4059-b44d-6137a4dd4987
 standard_extension_output = to_extend(plot(rand(4)).Plot)
 
 # ╔═╡ 8e7563ce-d2ba-4356-93e4-70ebe0f2be87
 weird_extension_output = to_extend(Example)
+
+# ╔═╡ 25b8a9d0-d790-4b18-854d-4392291db823
+getproperty(TestDirectExtension, :plot_this)
+
+# ╔═╡ 3c8d1e3c-f081-4b73-82ab-e0a9b3958c92
+TestDirectExtension.plot_this
+
+# ╔═╡ da703251-1f4a-4fa1-ba08-720bceb2ada6
+# ╠═╡ disabled = true
+#=╠═╡
+p = plot_this()
+  ╠═╡ =#
 
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """
@@ -430,11 +436,12 @@ version = "17.4.0+2"
 
 # ╔═╡ Cell order:
 # ╠═f6bb9eb6-1f66-424a-9043-607aeee0cd76
-# ╠═6721d53c-f94d-45ec-ad4e-be5e186fc58f
-# ╠═d456f788-244a-4be6-91dc-0c64ecdca071
 # ╠═abccfc80-afaf-4c54-b300-c0c893de3848
 # ╠═b93cdd74-1c65-4d15-a6e3-6c1855e37cce
 # ╠═675230da-e628-4059-b44d-6137a4dd4987
 # ╠═8e7563ce-d2ba-4356-93e4-70ebe0f2be87
+# ╠═25b8a9d0-d790-4b18-854d-4392291db823
+# ╠═3c8d1e3c-f081-4b73-82ab-e0a9b3958c92
+# ╠═da703251-1f4a-4fa1-ba08-720bceb2ada6
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.27
+# v0.19.38
 
 using Markdown
 using InteractiveUtils
@@ -39,8 +39,14 @@ end
 	using PackageModule
 end
 
+# ╔═╡ 6721d53c-f94d-45ec-ad4e-be5e186fc58f
+PlutoDevMacros.FromPackage.getfirst
+
+# ╔═╡ d456f788-244a-4be6-91dc-0c64ecdca071
+PlutoDevMacros.FromPackage.bare_project
+
 # ╔═╡ 675230da-e628-4059-b44d-6137a4dd4987
-standard_extension_output = to_extend(plot(rand(4)))
+standard_extension_output = to_extend(plot(rand(4)).Plot)
 
 # ╔═╡ 8e7563ce-d2ba-4356-93e4-70ebe0f2be87
 weird_extension_output = to_extend(Example)
@@ -60,15 +66,15 @@ PlutoPlotly = "~0.3.9"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.2"
+julia_version = "1.10.1"
 manifest_format = "2.0"
 project_hash = "d71ceab842b685ad63f73720ca026030946780f6"
 
 [[deps.AbstractPlutoDingetjes]]
 deps = ["Pkg"]
-git-tree-sha1 = "91bd53c39b9cbfb5ef4b015e8b582d344532bd0a"
+git-tree-sha1 = "c278dfab760520b8bb7e9511b968bf4ba38b7acc"
 uuid = "6e696c72-6542-2067-7265-42206c756150"
-version = "1.2.0"
+version = "1.2.3"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -82,9 +88,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
-git-tree-sha1 = "d9a8f86737b665e15a9641ecbac64deef9ce6724"
+git-tree-sha1 = "67c1f244b991cad9b0aa4b7540fb758c2488b129"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.23.0"
+version = "3.24.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -113,7 +119,7 @@ version = "0.12.10"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+0"
+version = "1.1.0+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -152,21 +158,21 @@ version = "0.8.4"
 
 [[deps.Hyperscript]]
 deps = ["Test"]
-git-tree-sha1 = "8d511d5b81240fc8e6802386302675bdf47737b9"
+git-tree-sha1 = "179267cfa5e712760cd43dcae385d7ea90cc25a4"
 uuid = "47d2ed2b-36de-50cf-bf87-49c2cf4b8b91"
-version = "0.0.4"
+version = "0.0.5"
 
 [[deps.HypertextLiteral]]
 deps = ["Tricks"]
-git-tree-sha1 = "c47c5fa4c5308f27ccaac35504858d8914e102f9"
+git-tree-sha1 = "7134810b1afce04bbc1045ca1985fbe81ce17653"
 uuid = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-version = "0.9.4"
+version = "0.9.5"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "d75853a0bdbfb1ac815478bacd89cd27b550ace6"
+git-tree-sha1 = "8b72179abc660bfab5e28472e019392b97d0985c"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.3"
+version = "0.2.4"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -179,28 +185,33 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
 [[deps.LaTeXStrings]]
-git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
+git-tree-sha1 = "50901ebc375ed41dbf8058da26f9de442febbbec"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -224,14 +235,14 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.2+1"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2023.1.10"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -240,17 +251,17 @@ version = "1.2.0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.21+4"
+version = "0.3.23+4"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "2e73fe17cac3c62ad1aebe70d44c963c3cfdc3e3"
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.6.2"
+version = "1.6.3"
 
 [[deps.PackageExtensionCompat]]
-git-tree-sha1 = "f9b1e033c2b1205cf30fd119f4e50881316c1923"
+git-tree-sha1 = "fb28e33b8a95c4cee25ce296c817d89cc2e53518"
 uuid = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-version = "1.0.1"
+version = "1.0.2"
 weakdeps = ["Requires", "TOML"]
 
 [[deps.Parameters]]
@@ -261,14 +272,14 @@ version = "0.12.3"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
+git-tree-sha1 = "8489905bcdbcfac64d1daa51ca07c0d8f0283821"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.7.2"
+version = "2.8.1"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.10.0"
 
 [[deps.PlotlyBase]]
 deps = ["ColorSchemes", "Dates", "DelimitedFiles", "DocStringExtensions", "JSON", "LaTeXStrings", "Logging", "Parameters", "Pkg", "REPL", "Requires", "Statistics", "UUIDs"]
@@ -290,21 +301,21 @@ version = "0.3.9"
 
 [[deps.PlutoUI]]
 deps = ["AbstractPlutoDingetjes", "Base64", "ColorTypes", "Dates", "FixedPointNumbers", "Hyperscript", "HypertextLiteral", "IOCapture", "InteractiveUtils", "JSON", "Logging", "MIMEs", "Markdown", "Random", "Reexport", "URIs", "UUIDs"]
-git-tree-sha1 = "e47cd150dbe0443c3a3651bc5b9cbd5576ab75b7"
+git-tree-sha1 = "a6783c887ca59ce7e97ed630b74ca1f10aefb74d"
 uuid = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
-version = "0.7.52"
+version = "0.7.57"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.1.2"
+version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.0"
+version = "1.4.1"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -315,7 +326,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.Reexport]]
@@ -342,16 +353,17 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.9.0"
+version = "1.10.0"
 
 [[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
 uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "5.10.1+6"
+version = "7.2.1+1"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -374,14 +386,14 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.Tricks]]
-git-tree-sha1 = "aadb748be58b492045b4f56166b5188aa63ce549"
+git-tree-sha1 = "eae1bb484cd63b36999ee58be2de6c178105112f"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.URIs]]
-git-tree-sha1 = "b7a5e99f24892b6824a954199a45e9ffcc1c70f0"
+git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.5.0"
+version = "1.5.1"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -398,26 +410,28 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+0"
+version = "5.8.0+1"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"
 """
 
 # ╔═╡ Cell order:
 # ╠═f6bb9eb6-1f66-424a-9043-607aeee0cd76
+# ╠═6721d53c-f94d-45ec-ad4e-be5e186fc58f
+# ╠═d456f788-244a-4be6-91dc-0c64ecdca071
 # ╠═abccfc80-afaf-4c54-b300-c0c893de3848
 # ╠═b93cdd74-1c65-4d15-a6e3-6c1855e37cce
 # ╠═675230da-e628-4059-b44d-6137a4dd4987

--- a/test/TestIndirectExtension/Project.toml
+++ b/test/TestIndirectExtension/Project.toml
@@ -5,4 +5,3 @@ version = "0.1.0"
 
 [deps]
 PlutoPlotly = "8e989ff0-3d88-8e9f-f020-2b208a939ff0"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/test/TestIndirectExtension/test_extension.jl
+++ b/test/TestIndirectExtension/test_extension.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.27
+# v0.19.39
 
 using Markdown
 using InteractiveUtils
@@ -54,7 +54,7 @@ PlotlyKaleido = "~2.1.0"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.9.2"
+julia_version = "1.10.1"
 manifest_format = "2.0"
 project_hash = "a306e345b2ba616e53c5188b7eca690040bebb51"
 
@@ -105,21 +105,26 @@ version = "0.2.1+0"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "8.4.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
+version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -134,14 +139,14 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+0"
+version = "2.28.2+1"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.10.11"
+version = "2023.1.10"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -156,7 +161,7 @@ version = "2.7.2"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.9.2"
+version = "1.10.0"
 
 [[deps.PlotlyKaleido]]
 deps = ["Base64", "JSON", "Kaleido_jll"]
@@ -185,7 +190,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.SHA]]
@@ -218,17 +223,17 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+0"
+version = "1.2.13+1"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
+version = "1.52.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
+version = "17.4.0+2"
 """
 
 # ╔═╡ Cell order:

--- a/test/TestIndirectExtension/test_extension.jl
+++ b/test/TestIndirectExtension/test_extension.jl
@@ -6,16 +6,16 @@ using InteractiveUtils
 
 # ╔═╡ f6bb9eb6-1f66-424a-9043-607aeee0cd76
 begin
-	parent_project = Base.current_project(@__FILE__)
+	test_project = Base.current_project(normpath(@__DIR__, ".."))
 	notebook_project = Base.active_project()
 	plutodevmacros_project= Base.current_project(normpath(@__DIR__, "../..")) 
 	Base.eval(Main, quote # instantiate the parent env, mostly for CI
 		import Pkg
-		Pkg.activate($parent_project)
+		Pkg.activate($test_project)
 		Pkg.instantiate()
 		Pkg.activate($notebook_project)
 	end)
-	pushfirst!(LOAD_PATH, parent_project) # This contains Revise
+	pushfirst!(LOAD_PATH, test_project) # This contains Revise
 	pushfirst!(LOAD_PATH, plutodevmacros_project) # This loads the PlutoDevMacros environment, so we can do import with the latest version
 	try
 		Base.eval(Main, :(import Revise))

--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.0"
+julia_version = "1.10.1"
 manifest_format = "2.0"
 project_hash = "312792d949ca909f2f223c32651672a933fb0970"
 
@@ -35,7 +35,7 @@ version = "1.3.5"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.5+1"
+version = "1.1.0+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -77,9 +77,9 @@ version = "0.21.4"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "04663b9e1eb0d0eabf76a6d0752e0dac83d53b36"
+git-tree-sha1 = "7b762d81887160169ddfc93a47e5fd7a6a3e78ef"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.9.28"
+version = "0.9.29"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -150,7 +150,7 @@ version = "1.2.0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+2"
+version = "0.3.23+4"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
@@ -210,9 +210,9 @@ version = "1.3.0"
 
 [[deps.Revise]]
 deps = ["CodeTracking", "Distributed", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Pkg", "REPL", "Requires", "UUIDs", "Unicode"]
-git-tree-sha1 = "3fe4e5b9cdbb9bbc851c57b149e516acc07f8f72"
+git-tree-sha1 = "12aa2d7593df490c407a3bbd8b86b8b515017f3e"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.5.13"
+version = "3.5.14"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/test/TestParseError/parseerror_notebook.jl
+++ b/test/TestParseError/parseerror_notebook.jl
@@ -1,21 +1,21 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.19.39
 
 using Markdown
 using InteractiveUtils
 
 # ╔═╡ d4f2f0ca-c463-4318-8fe8-ad41ae9ca998
 begin
-	parent_project = Base.current_project(normpath(@__DIR__, ".."))
+	test_project = Base.current_project(normpath(@__DIR__, ".."))
 	notebook_project = Base.active_project()
 	plutodevmacros_project= Base.current_project(normpath(@__DIR__, "../..")) 
 	Base.eval(Main, quote # instantiate the parent env, mostly for CI
 		import Pkg
-		Pkg.activate($parent_project)
+		Pkg.activate($test_project)
 		Pkg.instantiate()
 		Pkg.activate($notebook_project)
 	end)
-	pushfirst!(LOAD_PATH, parent_project) # This contains Revise
+	pushfirst!(LOAD_PATH, test_project) # This contains Revise
 	pushfirst!(LOAD_PATH, plutodevmacros_project) # This loads the PlutoDevMacros environment, so we can do import with the latest version
 	try
 		Base.eval(Main, :(import Revise))

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, package_dependencies, extract_module_expression
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, ENVS
 import Pkg
 
 using Test
@@ -18,9 +18,6 @@ outpluto_caller = abspath(@__DIR__,"../..")
 inpluto_caller = join([outpluto_caller, "#==#", "00000000-0000-0000-0000-000000000000"])
 
 @testset "Errors" begin
-    @test_throws "No parent project" mktempdir() do tmpdir
-            package_dependencies(tmpdir)
-    end
     @test_throws "No project" mktempdir() do tmpdir
             get_package_data(tmpdir)
     end 

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange
 import Pkg
 
 using Test
@@ -167,6 +167,11 @@ function clean_expr(ex)
 end
 
 @testset "Skip Lines" begin
+    # Some coverage
+    ln = LineNumberNode(3, Symbol(@__FILE__))
+    lnr = LineNumberRange(ln)
+    @test lnr.first == lnr.last
+    @test _inrange(ln, ln)
     @testset "Parsing" begin
         function iseq(lr1::LineNumberRange, lr2::LineNumberRange)
             lr1.first == lr2.first && lr1.last == lr2.last

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, ENVS
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression
 import Pkg
 
 using Test

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -12,7 +12,7 @@ pop!(LOAD_PATH)
 
 # We point at the helpers file inside the FromPackage submodule, we only load the constants in the Loaded submodule
 outpackage_target = abspath(@__DIR__,"../..")
-inpackage_target = joinpath(outpackage_target, "src/frompackage/helpers.jl")
+inpackage_target = joinpath(outpackage_target, "src/frompackage/types.jl")
 # We simulate a caller from a notebook by appending a fake cell-id
 outpluto_caller = abspath(@__DIR__,"../..")
 inpluto_caller = join([outpluto_caller, "#==#", "00000000-0000-0000-0000-000000000000"])

--- a/test/frompackage/pluto_package_extensions.jl
+++ b/test/frompackage/pluto_package_extensions.jl
@@ -8,9 +8,13 @@ direct_path = normpath(@__DIR__, "../TestDirectExtension/")
 
 # We add PlotlyExtensionsHelper manually in the test as it's not registered
 c = Context(;env = EnvCache(joinpath(direct_path, "Project.toml")))
-Pkg.add(c, [
-    PackageSpec(; name = "PlotlyExtensionsHelper", url = "https://github.com/disberd/PlotlyExtensionsHelper.jl", rev = "main")
-])
+let
+    url = "https://github.com/disberd/PlotlyExtensionsHelper.jl" 
+    rev = "main"
+    Pkg.add(c, [
+        PackageSpec(; url, rev, repo = Pkg.Types.GitRepo(;source = url, rev) )
+    ])
+end
 
 function noerror(cell; verbose=true)
     if cell.errored && verbose

--- a/test/frompackage/pluto_package_extensions.jl
+++ b/test/frompackage/pluto_package_extensions.jl
@@ -1,8 +1,16 @@
 using Test
+import Pkg
+import Pkg.Types: Context, EnvCache, PackageSpec
 import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell, project_relative_path, SessionActions, load_notebook, Configuration
 
 indirect_path = normpath(@__DIR__, "../TestIndirectExtension/")
 direct_path = normpath(@__DIR__, "../TestDirectExtension/")
+
+# We add PlotlyExtensionsHelper manually in the test as it's not registered
+c = Context(;env = EnvCache(joinpath(direct_path, "Project.toml")))
+Pkg.add(c, [
+    PackageSpec(; name = "PlotlyExtensionsHelper", url = "https://github.com/disberd/PlotlyExtensionsHelper.jl", rev = "main")
+])
 
 function noerror(cell; verbose=true)
     if cell.errored && verbose
@@ -32,6 +40,7 @@ end
     nb = SessionActions.open(ss, path; run_async=false)
     @test eval_in_nb((ss, nb), :standard_extension_output) === "Standard Extension works!"
     @test eval_in_nb((ss, nb), :weird_extension_output) === "Weird Extension name works!"
+    @test eval_in_nb((ss, nb), :(p isa PlutoPlot)) === true
     for cell in nb.cells
         @test noerror(cell)
     end

--- a/test/frompackage/pluto_package_extensions.jl
+++ b/test/frompackage/pluto_package_extensions.jl
@@ -1,6 +1,6 @@
 using Test
 import Pkg
-import Pkg.Types: Context, EnvCache, PackageSpec
+import Pkg.Types: Context, EnvCache, PackageSpec, GitRepo
 import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell, project_relative_path, SessionActions, load_notebook, Configuration
 
 indirect_path = normpath(@__DIR__, "../TestIndirectExtension/")
@@ -11,8 +11,9 @@ c = Context(;env = EnvCache(joinpath(direct_path, "Project.toml")))
 let
     url = "https://github.com/disberd/PlotlyExtensionsHelper.jl" 
     rev = "main"
+    repo = GitRepo(;source = url, rev)
     Pkg.add(c, [
-        PackageSpec(; url, rev, repo = Pkg.Types.GitRepo(;source = url, rev) )
+        PackageSpec(; url, rev, repo)
     ])
 end
 

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -1,7 +1,7 @@
 using Test
 import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell, project_relative_path, SessionActions, load_notebook, Configuration
 
-include("helpers.jl")
+include(joinpath(@__DIR__, "helpers.jl"))
 
 instantiate_and_import(:(import TestPackage), normpath(@__DIR__, "../TestPackage"))
 


### PR DESCRIPTION
This MR changes the way the internals of FromPackage to better support more complex extensions cases.

Now the package defines `EnvCacheGroup` which is struct with 3 separate `EnvCache` (from `Pkg.Types`) keeping tracks of the three environments we are interested in:
- The notebook environment
- The target environment (which is the one of the path of the parent in case of `@fromparent`, or of the path provided to `@frompackage`)
- The active environment. This is new and is the environment which is added permanently to the LOAD_PATH and is a mirror of the `target` environment

The `active` environment mirroring target is needed to fix #32 and is also compatible with the planned feature of providing a specific environment which might contain more than just the target package.

At every run of `@fromparent`/`@frompackage`, the target project/manifest files are reparsed and eventually copied to the active environment which is also instantiated to keep them in sync.

Another addition is that now the `FromPackage` module holds an intially empty `LoadedModules` submodule which is populated with dependencies that are eventually requested for extensions. This module is also mirrored inside the `fromparent_module[]` (with the name `_LoadedModules_` to reduce name clashing probability) so that it's accessible from the notebook.
The list of dependencies that are potentially accessible from LoadedModules are the one in `Base.loaded_modules`, making this capable of also loading modules which are not direct dependencies of any of the environments in EnvCacheGroup. (This is required to fix #28).
For the moment direct target dependencies accessed through the `>.DirectDependency` synthax are still not loaded from `LoadedModules` but a next PR will also harmonize this.

Fixes #32 and #28 