### PR TITLE
Allow `import *` in `FromPackageImport`s

### DIFF
--- a/docs/src/frompackage/import_statements.md
+++ b/docs/src/frompackage/import_statements.md
@@ -56,11 +56,11 @@ A special kind parent module import is:
 ```julia
 import *
 ```
-which is equivalent to `import ParentModule: *`. 
+which is equivalent to:
+- `import ParentModule: *` if the `target` file provided to `@frompackage`/`@fromparent` **is** a file *included* in the target Package. 
+  - This tries to reproduce within the namespace of the calling notebook, the namespace that would be visible by the notebook file when it is loaded as part of the Package module outside of Pluto.
+- `import PackageModule: *` if the `target` file provided to `@frompackage`/`@fromparent` **is not** a file *included* in the target Package. 
 
-This tries to reproduce within the namespace of the calling notebook, the
-namespace that would be visible by the notebook file when it is loaded as part
-of the Package module outside of Pluto.
 
 ## Imports from Direct dependencies
 

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -1,14 +1,3 @@
-# We define here the types to identify the imports
-abstract type ImportType end
-for name in (:FromParentImport, :FromPackageImport, :FromDepsImport, :RelativeImport)
-	expr = :(struct $name <: ImportType
-		mod_name::Symbol
-	end) 
-	eval(expr)
-end
-
-
-
 # This funtion tries to look within the expression fed to @frompackage to look for calls to @skiplines
 function process_skiplines!(ex, dict)
 	block = if Meta.isexpr(ex, :block)

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -91,9 +91,12 @@ end
 function import_type(args, dict)
 	first_name = args[1]
 	mod_name = Symbol(dict["name"])
+	if first_name === :* 
+		return target_found(dict) ? FromParentImport(mod_name) : FromPackageImport(mod_name)
+	end
 	first_name ∈ (:PackageModule, mod_name, :^) && return FromPackageImport(mod_name)	
 	first_name === :. && return RelativeImport(mod_name)
-	first_name ∈ (:*, :ParentModule, :<) && return FromParentImport(mod_name)
+	first_name ∈ (:ParentModule, :<) && return FromParentImport(mod_name)
 	(;direct, indirect) = dict["PkgInfo"]
 	first_name === :> && String(args[2]) ∈ keys(direct) && return FromDepsImport(mod_name)
 	# String(first_name) ∈ _stdlibs && return FromDepsImport(mod_name)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -6,6 +6,17 @@ StopEval(reason::String) = StopEval(reason, LineNumberNode(0))
 
 # Function to clean the filepath from the Pluto cell delimiter if present
 cleanpath(path::String) = first(split(path, "#==#")) |> abspath
+# Check if two paths are equal, ignoring case on the drive letter on windows.
+function issamepath(path1::String, path2::String)
+	path1 = abspath(path1)
+	path2 = abspath(path2)
+	if Sys.iswindows()
+		uppercase(path1[1]) == uppercase(path2[1]) || return false
+		path1[2:end] == path2[2:end] && return true
+	else
+		path1 == path2 && return true
+	end
+end
 
 ## general
 function eval_in_module(_mod, line_and_ex, dict)
@@ -37,7 +48,7 @@ function eval_include_expr(_mod, loc, ex, dict)
 		abspath(calling_dir, filename_str)
 	end
 	# We check whether the file to be included is the target put as input to the macro
-	if filepath == cleanpath(dict["target"]) 
+	if issamepath(filepath, cleanpath(dict["target"]))
 		# We have to store the Module path
 		package_name = Symbol(dict["name"])
 		current = _mod

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -56,3 +56,11 @@ function _inrange(ln::LineNumberNode, lnr::LineNumberRange)
 end
 _inrange(ln::LineNumberNode, ln2::LineNumberNode) = ln === ln2
 
+# We define here the types to identify the imports
+abstract type ImportType end
+for name in (:FromParentImport, :FromPackageImport, :FromDepsImport, :RelativeImport)
+	expr = :(struct $name <: ImportType
+		mod_name::Symbol
+	end) 
+	eval(expr)
+end


### PR DESCRIPTION
This PR enables the `import *` synthax even in cases where the `@fromparent`/`@frompackage` `target` is not a file included in the targeted package.

In those cases, `import *` behaves equivalently to `import ^: *`.

Fixes #26 