### PR TITLE
fix error when compat entry is only in weakdeps

### DIFF
--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -70,7 +70,7 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 		mkpath(dirname(active_manifest))
 		# We copy a reduced version of the project, only with deps and compat
         pd = ecg.target.project.other
-        ad = Dict{String, Any}((k => pd[k] for k in ("deps", "compat") if haskey(pd, k)))
+        ad = Dict{String, Any}((k => pd[k] for k in ("deps", "compat", "weakdeps") if haskey(pd, k)))
         write_project(ad, active_project)
         # We copy the Manifest
         cp(target_manifest, active_manifest; force = true)

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -68,7 +68,7 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 	end
     if force
 		mkpath(dirname(active_manifest))
-		# We copy a reduced version of the project, only with deps and compat
+		# We copy a reduced version of the project, only with deps, weakdeps and compat
         pd = ecg.target.project.other
         ad = Dict{String, Any}((k => pd[k] for k in ("deps", "compat", "weakdeps") if haskey(pd, k)))
         write_project(ad, active_project)

--- a/test/TestDirectExtension/Project.toml
+++ b/test/TestDirectExtension/Project.toml
@@ -13,3 +13,6 @@ PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 [extensions]
 Magic = "Example"
 PlotlyBaseExt = "PlotlyBase"
+
+[compat]
+PlotlyBase = "0.8"

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.39
+# v0.19.38
 
 using Markdown
 using InteractiveUtils


### PR DESCRIPTION
This PR fixes an error happening when the target project has compat entries for packages that are only weakdeps.

This was caused by only copying `deps` and `compat` from the target to the active project