### PR TITLE
Fix import statements of with PackageModule as first module identifier

### DIFF
--- a/src/frompackage/code_parsing.jl
+++ b/src/frompackage/code_parsing.jl
@@ -28,8 +28,20 @@ function remove_pluto_exprs(ex)
 end
 remove_pluto_exprs(ex, args...) = remove_pluto_exprs(ex)
 
+# This will substitute PackageName with the correct path pointed to the loaded module
+function modify_package_using!(ex::Expr, loc, package_dict::Dict, eval_module::Module)
+	Meta.isexpr(ex, (:using, :import)) || return true
+	package_name = Symbol(package_dict["name"])
+	package_expr, _ = extract_import_args(ex)
+	package_expr_args = package_expr.args
+	extracted_package_name = first(package_expr_args)
+	if extracted_package_name === package_name
+		prepend!(package_expr_args, modname_path(fromparent_module[])) 
+	end
+	return true
+end
+
 # This will simply make the using/import statements of the calling package point to the parent module
-modify_extension_using!(x, args...) = true
 function modify_extension_using!(ex::Expr, loc, package_dict::Dict, eval_module::Module)
 	Meta.isexpr(ex, (:using, :import)) || return true
 	has_extensions(package_dict) || return true
@@ -46,10 +58,7 @@ function modify_extension_using!(ex::Expr, loc, package_dict::Dict, eval_module:
 	package_expr, _ = extract_import_args(ex)
 	package_expr_args = package_expr.args
 	extracted_package_name = first(package_expr_args)
-	if extracted_package_name === package_name
-		# We just add .. to the name because the extension module was added to the toplevel of the parent
-		prepend!(package_expr_args, (:., :.))
-	elseif extracted_package_name === weakdep
+	if extracted_package_name === weakdep
 		# We first add :_LoadedModules_
 		pushfirst!(package_expr_args, :_LoadedModules_)
 		# We also add the module path of the fromparent_module which contains _LoadedModules_
@@ -77,7 +86,7 @@ function process_expr!(ex, loc, dict, eval_module)
 	ex isa Expr || return true # Apart from Nothing, we keep everything that is not an expr
 	_is_block(ex) && return process_block!(ex, loc, dict, eval_module)
 	_is_include(ex) && error("A call to include not at toplevel was found around line $loc. This is not permitted")
-	keep = all((remove_pluto_exprs, modify_extension_using!)) do f
+	keep = all((remove_pluto_exprs, modify_package_using!, modify_extension_using!)) do f
 		f(ex, loc, dict, eval_module)
 	end
 end

--- a/test/TestPackage/out_notebook.jl
+++ b/test/TestPackage/out_notebook.jl
@@ -29,9 +29,9 @@ this_file = relpath(split(@__FILE__,"#==#")[1], dirname(dirname(dirname(@__DIR__
 @fromparent begin
 	import TestPackage
 	@skiplines begin
-		"20" # Skip line 13 in the main file TestPackage.jl, which defines module Inner
+		"22" # Skip line in the main file TestPackage.jl which defines module Inner
 		"test_macro2.jl" # This skips the whole file test_macro2.jl
-		"31-32" # This skips from line 24 to 25 in the main file, including extrema. Which are the 2 include statements of the inner SpecificImport module
+		"33-34" # This skips lines in the main file, which are the 2 include statements of the inner SpecificImport module
 		"test_macro1.jl:::28-10000" # This skips parts of test_macro1.jl
 	end
 end

--- a/test/TestPackage/src/TestPackage.jl
+++ b/test/TestPackage/src/TestPackage.jl
@@ -15,6 +15,8 @@ module SUBINIT
     end
 end
 
+import TestPackage.SUBINIT: TEST_SUBINIT
+
 include("notebook1.jl")
 
 module Inner


### PR DESCRIPTION
This PR fixs an error that was thrown if the target package `PackageName` was encountered as first name identifier in an import/using statement inside the module itself.

Something like `import PackageName.SubModule: var`.

In this case, `PackageName` is substituted with the full path of the target module gernated by the macro (e.g. `Main.#fromparent_module#.PackageName`.

This substitution shall also work on import statements like `import PkgA, PkgB`.