### PR TITLE
Allow loading indirect imports

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,8 +33,8 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -42,6 +42,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -167,7 +167,9 @@ function valid_outside_pluto!(ex, dict)
 		popfirst!(args)
 		s = String(args[1])
 		(;direct, indirect) = dict["PkgInfo"]
-		s ∈ keys(direct) && return true
+		if s ∈ keys(direct) || s ∈ keys(indirect) 
+            return true
+        end
 	end
 	# s ∈ _stdlibs && return true
 	# s ∈ keys(indirect) && return true

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -109,7 +109,7 @@ end
 
 function deps_submodule_expr(dict)
 	(;direct) = dict["PkgInfo"]
-	ex = :(module _DirectDeps_ end)
+	ex = :(module _DepsImports_ end)
 	toplevel = ex.args[end]
 	args = toplevel.args
 	for pkg in values(direct)

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -38,9 +38,20 @@ _inrange(ln::LineNumberNode, ln2::LineNumberNode) = ln === ln2
 
 # We define here the types to identify the imports
 abstract type ImportType end
-for name in (:FromParentImport, :FromPackageImport, :FromDepsImport, :RelativeImport)
+for name in (:FromParentImport, :FromPackageImport, :RelativeImport)
 	expr = :(struct $name <: ImportType
 		mod_name::Symbol
 	end) 
 	eval(expr)
+end
+# We define the FromDepsImport outside as it has custom fields
+struct FromDepsImport <: ImportType
+    mod_name::Symbol
+    id::Base.PkgId
+    direct::Bool
+end
+function FromDepsImport(mod_name, pkginfo::PkgInfo, direct::Bool)
+    uuid = pkginfo.uuid
+    id = Base.PkgId(uuid, pkginfo.name)
+    FromDepsImport(mod_name, id, direct)
 end


### PR DESCRIPTION
This PR adds the possibility of loading indirect dependencies (i.e. in the Manifest but not in the Project) of the target package. It fixes #40.
Note that there may be occasions where an indirect dependency can not be loaded. At the moment the package resorts to loading the indirect dependency's module from `Base.loaded_modules`, so if the indirect dependency was not directly loaded in the julia session, this will not work.

This should be rare, we are already explicitly loading each direct dependency (even if not explicitly loaded in the target package) so as to load all of their indirect dependencies. It might still happen that some package is a dependency of an indirect project dependency that is not directly loaded in its defining package, leading to failure of this approach.

Additionally, the package now throws a specific error if some package that is not among direct or indirect dependencies of the target is attempted to be loaded. This last part fixes #41 