### PR TITLE
Enable re-exporting names from `using` statements in catch-all expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/build/
 pluto_test*.jl
 test*.jl
 !test/TestDevDependency/**
+!test/TestUsingNames/**
+test/TestUsingNames/Manifest.toml

--- a/src/frompackage/code_parsing.jl
+++ b/src/frompackage/code_parsing.jl
@@ -1,30 +1,30 @@
 function extract_file_ast(filename)
-	code = read(filename, String)
-	ast = Meta.parseall(code; filename)
-	@assert Meta.isexpr(ast, :toplevel)
-	ast
+    code = read(filename, String)
+    ast = Meta.parseall(code; filename)
+    @assert Meta.isexpr(ast, :toplevel)
+    ast
 end
 
 ## Extract Module Expression
 
 function extract_module_expression(module_filepath::AbstractString)
-	ast = extract_file_ast(module_filepath)
-	mod_exp = getfirst(x -> Meta.isexpr(x, :module), ast.args)
-	mod_exp === nothing || return mod_exp
-	# We throw an error as parsing did not create a valid `module` expression
-	ex = last(ast.args)
-	e = ex.args[end]
-	if VERSION < v"1.10"
-		e isa String && error("Parsing $module_filepath did not generate a valid `module` expression because of the following error:\n$e")
-	else
-		throw(e)
-	end
+    ast = extract_file_ast(module_filepath)
+    mod_exp = getfirst(x -> Meta.isexpr(x, :module), ast.args)
+    mod_exp === nothing || return mod_exp
+    # We throw an error as parsing did not create a valid `module` expression
+    ex = last(ast.args)
+    e = ex.args[end]
+    if VERSION < v"1.10"
+        e isa String && error("Parsing $module_filepath did not generate a valid `module` expression because of the following error:\n$e")
+    else
+        throw(e)
+    end
 end
 
 ## Remove Pluto Exprs
 function remove_pluto_exprs(ex)
-	ex.head == :(=) && ex.args[1] ∈ (:PLUTO_PROJECT_TOML_CONTENTS, :PLUTO_MANIFEST_TOML_CONTENTS) && return false
-	return true
+    ex.head == :(=) && ex.args[1] ∈ (:PLUTO_PROJECT_TOML_CONTENTS, :PLUTO_MANIFEST_TOML_CONTENTS) && return false
+    return true
 end
 remove_pluto_exprs(ex, args...) = remove_pluto_exprs(ex)
 
@@ -44,100 +44,100 @@ function add_using_names!(package_dict::Dict, package_exprs, imported_names_args
             new_name::Symbol = name_expr.args[1]
             push!(explicit_names, new_name)
         end
-	end
+    end
 end
 
 # This will substitute PackageName with the correct path pointed to the loaded module
 function modify_package_using!(ex::Expr, loc, package_dict::Dict, eval_module::Module)
-	Meta.isexpr(ex, (:using, :import)) || return true
-	package_name = Symbol(package_dict["name"])
-	package_exprs, imported_names_args = if length(ex.args) === 1
-		# We are in the form import PkgName: vars...
-		package_expr, imported_names = extract_import_args(ex)
-		[package_expr], imported_names
-	else
-		# We are in the form import PkgA, PkgB
-		ex.args, Expr[]
-	end
+    Meta.isexpr(ex, (:using, :import)) || return true
+    package_name = Symbol(package_dict["name"])
+    package_exprs, imported_names_args = if length(ex.args) === 1
+        # We are in the form import PkgName: vars...
+        package_expr, imported_names = extract_import_args(ex)
+        [package_expr], imported_names
+    else
+        # We are in the form import PkgA, PkgB
+        ex.args, Expr[]
+    end
     if ex.head === :using
         add_using_names!(package_dict, package_exprs, imported_names_args)
     end
-	for package_expr in package_exprs
-		package_expr_args = package_expr.args
-		extracted_package_name = first(package_expr_args)
-		if extracted_package_name === package_name
+    for package_expr in package_exprs
+        package_expr_args = package_expr.args
+        extracted_package_name = first(package_expr_args)
+        if extracted_package_name === package_name
             # We modify the specific using expression to point to the correct module path
-			prepend!(package_expr_args, modname_path(fromparent_module[])) 
-		end
-	end
-	return true
+            prepend!(package_expr_args, modname_path(fromparent_module[]))
+        end
+    end
+    return true
 end
 
 # This will simply make the using/import statements of the calling package point to the parent module
 function modify_extension_using!(ex::Expr, loc, package_dict::Dict, eval_module::Module)
-	Meta.isexpr(ex, (:using, :import)) || return true
-	has_extensions(package_dict) || return true
-	loaded_exts = get!(package_dict, "loaded extensions", Set{Symbol}())
-	package_name = Symbol(package_dict["name"])
-	# If we are not currently evaluating expressions inside the extension module, we return
-	eval_module_name = nameof(eval_module)
-	eval_module_name in loaded_exts || return true
-	ecg = default_ecg()
-	target_project = ecg |> get_target |> get_project
-	ext_mod_name = String(eval_module_name)
-	# Extract the name of the weakdep that triggered this extension
-	weakdep = target_project.exts[ext_mod_name] |> Symbol
-	package_expr, _ = extract_import_args(ex)
-	package_expr_args = package_expr.args
-	extracted_package_name = first(package_expr_args)
-	if extracted_package_name === weakdep
-		# We first add :_LoadedModules_
-		pushfirst!(package_expr_args, :_LoadedModules_)
-		# We also add the module path of the fromparent_module which contains _LoadedModules_
-		prepend!(package_expr_args, modname_path(fromparent_module[])) 
-	end
-	return true
+    Meta.isexpr(ex, (:using, :import)) || return true
+    has_extensions(package_dict) || return true
+    loaded_exts = get!(package_dict, "loaded extensions", Set{Symbol}())
+    package_name = Symbol(package_dict["name"])
+    # If we are not currently evaluating expressions inside the extension module, we return
+    eval_module_name = nameof(eval_module)
+    eval_module_name in loaded_exts || return true
+    ecg = default_ecg()
+    target_project = ecg |> get_target |> get_project
+    ext_mod_name = String(eval_module_name)
+    # Extract the name of the weakdep that triggered this extension
+    weakdep = target_project.exts[ext_mod_name] |> Symbol
+    package_expr, _ = extract_import_args(ex)
+    package_expr_args = package_expr.args
+    extracted_package_name = first(package_expr_args)
+    if extracted_package_name === weakdep
+        # We first add :_LoadedModules_
+        pushfirst!(package_expr_args, :_LoadedModules_)
+        # We also add the module path of the fromparent_module which contains _LoadedModules_
+        prepend!(package_expr_args, modname_path(fromparent_module[]))
+    end
+    return true
 end
 
 _is_include(ex) = Meta.isexpr(ex, :call) && ex.args[1] === :include
 _is_block(ex) = Meta.isexpr(ex, :block)
 
 function should_skip(loc, lines_to_skip)
-	# We skip the line as it's in the list of lines to skip
-	skip = any(lines_to_skip) do lr
-		_inrange(loc, lr)
-	end
-	# skip && @info "Skipping $loc"
-	skip
+    # We skip the line as it's in the list of lines to skip
+    skip = any(lines_to_skip) do lr
+        _inrange(loc, lr)
+    end
+    # skip && @info "Skipping $loc"
+    skip
 end
 
 # process_expr, performs potential modification to ex and return true if this
 # expression has to be kept/evaluated
-function process_expr!(ex, loc, dict, eval_module) 
-	ex isa Nothing && return false # We skip nothings
-	ex isa Expr || return true # Apart from Nothing, we keep everything that is not an expr
-	_is_block(ex) && return process_block!(ex, loc, dict, eval_module)
-	_is_include(ex) && error("A call to include not at toplevel was found around line $loc. This is not permitted")
-	keep = all((remove_pluto_exprs, modify_package_using!, modify_extension_using!)) do f
-		f(ex, loc, dict, eval_module)
-	end
+function process_expr!(ex, loc, dict, eval_module)
+    ex isa Nothing && return false # We skip nothings
+    ex isa Expr || return true # Apart from Nothing, we keep everything that is not an expr
+    _is_block(ex) && return process_block!(ex, loc, dict, eval_module)
+    _is_include(ex) && error("A call to include not at toplevel was found around line $loc. This is not permitted")
+    keep = all((remove_pluto_exprs, modify_package_using!, modify_extension_using!)) do f
+        f(ex, loc, dict, eval_module)
+    end
 end
 
 # Process a begin-end block
 function process_block!(ex, loc, dict, eval_module)
-	# We create an array of flags to check which portions to keep
-	args = ex.args
-	loc_idx = 0
-	keep_inds = falses(length(args))
-	for (i, arg) in enumerate(args)
-		if arg isa LineNumberNode
-			loc = arg
-			loc_idx = i
-			continue
-		end
-		# We keep the LineNumberNode if it has at least a valid associated expression
-		keep_inds[loc_idx] |= keep_inds[i] = process_expr!(arg, loc, dict, eval_module)
-	end
-	keepat!(args, keep_inds)
-	return any(keep_inds)
+    # We create an array of flags to check which portions to keep
+    args = ex.args
+    loc_idx = 0
+    keep_inds = falses(length(args))
+    for (i, arg) in enumerate(args)
+        if arg isa LineNumberNode
+            loc = arg
+            loc_idx = i
+            continue
+        end
+        # We keep the LineNumberNode if it has at least a valid associated expression
+        keep_inds[loc_idx] |= keep_inds[i] = process_expr!(arg, loc, dict, eval_module)
+    end
+    keepat!(args, keep_inds)
+    return any(keep_inds)
 end

--- a/src/frompackage/code_parsing.jl
+++ b/src/frompackage/code_parsing.jl
@@ -68,7 +68,6 @@ function modify_package_using!(ex::Expr, loc, package_dict::Dict, eval_module::M
 		if extracted_package_name === package_name
             # We modify the specific using expression to point to the correct module path
 			prepend!(package_expr_args, modname_path(fromparent_module[])) 
-        else
 		end
 	end
 	return true

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -164,9 +164,18 @@ end
 getfirst(itr) = getfirst(x -> true, itr)
 
 ## filterednames
-function filterednames(m::Module; all = true, imported = true)
+function filterednames(m::Module; all = true, imported = true, explicit_names = nothing)
 	excluded = (:eval, :include, :_fromparent_dict_, Symbol("@bind"))
-	filter(names(m;all, imported)) do s
+    mod_names = names(m;all, imported)
+    filter_args = if explicit_names isa Set{Symbol}
+        for name in mod_names
+            push!(explicit_names, name)
+        end
+        collect(explicit_names)
+    else
+        mod_names
+    end
+	filter(filter_args) do s
 		Base.isgensym(s) && return false
 		s in excluded && return false
 		return true

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -261,10 +261,14 @@ function has_include_using!(ex)
     ex.args[1] === Symbol("@include_using") || return false
     # If we reach here, we have the include usings. We just extract the underlying expression
     actual_ex = ex.args[end]
+    # Check if this contains catchall
+    @assert try 
+        contains_catchall(actual_ex)
+    catch
+        false
+    end "You can only use @include_using with the catchall import statement (e.g. `@include_using import *`).\nInstead you passed [$(ex)] as input."
     ex.head = actual_ex.head
     ex.args = actual_ex.args
-    # Check if this contains catchall
-    @assert contains_catchall(ex) "You can only use @include_using with the catchall import statement (e.g. `@include_using import *`)."
     return true
 end
 

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -66,6 +66,9 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 	# We extract the parse dict
 	ex_args = if Meta.isexpr(ex, [:import, :using])
 		[ex]
+	elseif Meta.isexpr(ex, :macrocall) && ex.args[1] === Symbol("@include_using")
+        # This is @include_using
+        [ex]
 	elseif Meta.isexpr(ex, :block)
 		ex.args
 	else

--- a/test/TestUsingNames/Project.toml
+++ b/test/TestUsingNames/Project.toml
@@ -1,0 +1,10 @@
+name = "TestUsingNames"
+uuid = "ad5af708-d1e5-4d28-9e91-6798178ddbab"
+authors = ["Alberto Mengali <disberd@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/test/TestUsingNames/src/TestUsingNames.jl
+++ b/test/TestUsingNames/src/TestUsingNames.jl
@@ -1,0 +1,26 @@
+module TestUsingNames
+
+using Base64
+
+export top_level_func
+top_level_func() = 1
+
+module Test1
+    using Example
+    include("test1.jl")
+end
+
+module Test2
+    using ..Test1
+    include("test2.jl")
+end
+
+module Test3
+    using ..TestUsingNames
+    include("test3.jl")
+end
+
+include("../test_notebook1.jl")
+include("../test_notebook2.jl")
+
+end # module TestUsingNames

--- a/test/TestUsingNames/src/TestUsingNames.jl
+++ b/test/TestUsingNames/src/TestUsingNames.jl
@@ -11,7 +11,7 @@ module Test1
 end
 
 module Test2
-    using ..Test1
+    using ..Test1, Base64
     include("test2.jl")
 end
 

--- a/test/TestUsingNames/src/test1.jl
+++ b/test/TestUsingNames/src/test1.jl
@@ -1,0 +1,3 @@
+export test1
+
+test1() = 10

--- a/test/TestUsingNames/src/test2.jl
+++ b/test/TestUsingNames/src/test2.jl
@@ -1,0 +1,1 @@
+# This is irrelevant

--- a/test/TestUsingNames/src/test3.jl
+++ b/test/TestUsingNames/src/test3.jl
@@ -1,0 +1,1 @@
+# This is irrelevant

--- a/test/TestUsingNames/test_notebook1.jl
+++ b/test/TestUsingNames/test_notebook1.jl
@@ -1,0 +1,48 @@
+### A Pluto.jl notebook ###
+# v0.19.42
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ bb3dd7a0-19fc-11ef-093c-a938acaf0cf5
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	test_project = Base.current_project(normpath(@__DIR__, ".."))
+	notebook_project = Base.active_project()
+	plutodevmacros_project= Base.current_project(normpath(@__DIR__, "../..")) 
+	Base.eval(Main, quote # instantiate the parent env, mostly for CI
+		import Pkg
+		Pkg.activate($test_project)
+		Pkg.instantiate()
+		Pkg.activate($notebook_project)
+	end)
+	pushfirst!(LOAD_PATH, test_project) # This contains Revise
+	pushfirst!(LOAD_PATH, plutodevmacros_project) # This loads the PlutoDevMacros environment, so we can do import with the latest version
+	try
+		Base.eval(Main, :(import Revise))
+		Base.eval(Main, :(import PlutoDevMacros))
+	finally
+		popfirst!(LOAD_PATH) # Remove plutodevmacros env
+		popfirst!(LOAD_PATH) # Remove parent_env
+	end
+	using Main.Revise
+	using Main.PlutoDevMacros
+end
+  ╠═╡ =#
+
+# ╔═╡ 23a1bdef-5c31-4c90-a7f5-1f5a806d3d2e
+#=╠═╡
+@fromparent import *
+  ╠═╡ =#
+
+# ╔═╡ e4f436ed-27e9-4d19-98bd-c2b3021cf8bd
+# ╠═╡ skip_as_script = true
+#=╠═╡
+!isdefined(@__MODULE__, :base64encode) || error("base64encode from Base64 should not be defined")
+  ╠═╡ =#
+
+# ╔═╡ Cell order:
+# ╠═bb3dd7a0-19fc-11ef-093c-a938acaf0cf5
+# ╠═23a1bdef-5c31-4c90-a7f5-1f5a806d3d2e
+# ╠═e4f436ed-27e9-4d19-98bd-c2b3021cf8bd

--- a/test/TestUsingNames/test_notebook2.jl
+++ b/test/TestUsingNames/test_notebook2.jl
@@ -1,0 +1,48 @@
+### A Pluto.jl notebook ###
+# v0.19.42
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 4f8def86-f90b-4f74-ac47-93fe6e437cee
+# ╠═╡ skip_as_script = true
+#=╠═╡
+begin
+	test_project = Base.current_project(normpath(@__DIR__, ".."))
+	notebook_project = Base.active_project()
+	plutodevmacros_project= Base.current_project(normpath(@__DIR__, "../..")) 
+	Base.eval(Main, quote # instantiate the parent env, mostly for CI
+		import Pkg
+		Pkg.activate($test_project)
+		Pkg.instantiate()
+		Pkg.activate($notebook_project)
+	end)
+	pushfirst!(LOAD_PATH, test_project) # This contains Revise
+	pushfirst!(LOAD_PATH, plutodevmacros_project) # This loads the PlutoDevMacros environment, so we can do import with the latest version
+	try
+		Base.eval(Main, :(import Revise))
+		Base.eval(Main, :(import PlutoDevMacros))
+	finally
+		popfirst!(LOAD_PATH) # Remove plutodevmacros env
+		popfirst!(LOAD_PATH) # Remove parent_env
+	end
+	using Main.Revise
+	using Main.PlutoDevMacros
+end
+  ╠═╡ =#
+
+# ╔═╡ ac3d261a-86c9-453f-9d86-23a8f30ca583
+#=╠═╡
+@fromparent @include_using import *
+  ╠═╡ =#
+
+# ╔═╡ dd3f662f-e2ce-422d-a91a-487a4da359cc
+# ╠═╡ skip_as_script = true
+#=╠═╡
+isdefined(@__MODULE__, :base64encode) || error("base64encode from Base64 should be defined")
+  ╠═╡ =#
+
+# ╔═╡ Cell order:
+# ╠═4f8def86-f90b-4f74-ac47-93fe6e437cee
+# ╠═ac3d261a-86c9-453f-9d86-23a8f30ca583
+# ╠═dd3f662f-e2ce-422d-a91a-487a4da359cc

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -118,8 +118,10 @@ end
     # Test that the names are extracted correctly
     ex = parseinput(:(@include_using import *), dict)
     @test has_symbol(:test1, ex) # test1 is exported by Module Test1
+    @test has_symbol(:base64encode, ex) # test1 is exported by Module Base64
     ex = parseinput(:(import *), dict)
     @test !has_symbol(:test1, ex)
+    @test !has_symbol(:base64encode, ex)
 
     # Test3 - test3.jl
     target = "src/test3.jl"

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args
 import Pkg
 
 using Test
@@ -66,6 +66,7 @@ end
     @test invalid(:(import >.DataFrames)) # This is not a dependency
 
 
+
     # Here we test that the loaded TestPackage has the intended functionality
     # We verify that the relative import statement from @fromparent outside
     # of Pluto works as intended, correctly importing and extending
@@ -75,6 +76,68 @@ end
     @test testmethod(3.0) == "FLOAT"
 
     @test Issue2.foo(Issue2.c) !== nothing
+end
+
+@testset "Include using names" begin
+    target_dir = abspath(@__DIR__,"../TestUsingNames/")
+    function f(target)
+        target_file = joinpath(target_dir, target * "#==#00000000-0000-0000-0000-000000000000")
+        dict = get_package_data(target_file)
+        # Load the module
+        load_module_in_caller(dict, Main)
+        return dict
+    end
+    function has_symbol(symbol, ex::Expr)
+        _, args = extract_import_args(ex)
+        for ex in args
+            name = ex.args[1]
+            name === symbol && return true
+        end
+        return false
+    end
+    # Test1 - test1.jl
+    target = "src/test1.jl"
+    dict = f(target)
+    invalid(ex) = nothing === process_outside_pluto!(deepcopy(ex), dict)
+    # Test that this only works with catchall
+    @test_throws "You can only use @include_using" parseinput(:(@include_using import Downloads), dict)
+    # Test that it throws with ill-formed expression
+    @test_throws "You can only use @include_using" parseinput(:(@include_using), dict)
+
+    # Test that even with the @include_using macro in front the expression is filtered out outside Pluo
+    @test invalid(:(@include_using import *))
+    # Test that the names are extracted correctly
+    ex = parseinput(:(@include_using import *), dict)
+    @test has_symbol(:domath, ex)
+    ex = parseinput(:(import *), dict)
+    @test !has_symbol(:domath, ex)
+
+    # Test2 - test2.jl
+    target = "src/test2.jl"
+    dict = f(target)
+    # Test that the names are extracted correctly
+    ex = parseinput(:(@include_using import *), dict)
+    @test has_symbol(:test1, ex) # test1 is exported by Module Test1
+    ex = parseinput(:(import *), dict)
+    @test !has_symbol(:test1, ex)
+
+    # Test3 - test3.jl
+    target = "src/test3.jl"
+    dict = f(target)
+    # Test that the names are extracted correctly, :top_level_func is exported by TestUsingNames
+    ex = parseinput(:(@include_using import *), dict)
+    @test has_symbol(:top_level_func, ex)
+    ex = parseinput(:(import *), dict)
+    @test !has_symbol(:top_level_func, ex)
+
+    # Test from a file outside the package
+    target = ""
+    dict = f(target)
+    # Test that the names are extracted correctly, :base64encode is exported by Base64
+    ex = parseinput(:(@include_using import *), dict)
+    @test has_symbol(:base64encode, ex)
+    ex = parseinput(:(import *), dict)
+    @test !has_symbol(:base64encode, ex)
 end
 
 

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -100,3 +100,17 @@ srcdir = joinpath(@__DIR__, "../TestDevDependency/src/")
     end
     SessionActions.shutdown(ss, nb)
 end
+
+# We test @include_using (issue 11)
+srcdir = joinpath(@__DIR__, "../TestUsingNames/src/")
+@testset "Using Names" begin
+    ss = ServerSession(; options)
+    for filename in ["test_notebook1.jl", "test_notebook2.jl"]
+        path = abspath(srcdir, "..", filename)
+        nb = SessionActions.open(ss, path; run_async=false)
+        for cell in nb.cells
+            @test noerror(cell)
+        end
+        SessionActions.shutdown(ss, nb)
+    end
+end


### PR DESCRIPTION
This PR adds an opt-in way of re-import all names defined via `using` statements when using catch-all import expression in `@fromparent` or `@frompackage`.

To do so, just prepend the catch-all importstatement with the `@include_using` macro, as shown in the following example:
```julia
@fromparent @include_using import *
```
This macro is not actually defined in the package and only processed during macro expansion of `@frompackage`/`@fromparent`.

This is currently an opt-in to avoid a breaking change, but it will likely became the default (with an opt-out) in the next breaking release.

Fixes #11 