### PR TITLE
small fixes

### DIFF
--- a/docs/src/frompackage/basic_use.md
+++ b/docs/src/frompackage/basic_use.md
@@ -4,10 +4,10 @@
 @frompackage target import_block
 ```
 
-The `@frompackage` macro takes a local Package (derived from the `target` path), loads it as
-a submodule of the current Pluto workspace and then process the various
-import/using statements inside `import_block` to extract varables/functions from
-the local Package into the notebook workspace.
+The `@frompackage` macro takes a local Package (derived from the `target` path),
+loads it as a submodule of the current Pluto workspace and then process the
+various import/using statements inside `import_block` to extract
+varables/functions from the local Package into the notebook workspace.
 
 !!! note
     `@fromparent` is simply a convenience synthax that uses the calling notebook file as `target`. More details on how the target path is processed are given below.\
@@ -26,9 +26,10 @@ For this reason the *reload* of local code is only triggered manually within `@f
 
 ## `target` path
 
-The first argument to `@frompackage` (`target`) has to be a String containing the path (either
-absolute or relative to the file calling the macro) that points to a local
-Package (the path can be to any file or subfolder within the Package folder).
+The first argument to `@frompackage` (`target`) has to be an AbstractString (or
+a `@raw_str`) containing the path (either absolute or relative to the file
+calling the macro) that points to a local Package (the path can be to any file
+or subfolder within the Package folder).
 
 The main module of the package identified by the `target` path will be used as the module to process and load within the calling notebook
 

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -262,3 +262,14 @@ issamepath(path1::Symbol, path2::Symbol) = issamepath(String(path1), String(path
 
 # Create a Base.PkgId from a PkgInfo
 to_pkgid(p::PkgInfo) = Base.PkgId(p.uuid, p.name)
+
+# This will extract the string from a raw_str macro, and will throw an error otherwise
+function extract_raw_str(ex::Expr)
+    valid = Meta.isexpr(ex, :macrocall) && ex.args[1] === Symbol("@raw_str")
+    if valid
+        return ex.args[end], true
+    else
+        return "", false
+    end
+end
+extract_raw_str(s::AbstractString) = String(s), true

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -81,8 +81,6 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 	end
 	# Now we add the call to maybe load the package extensions
 	push!(args, :($load_package_extensions($dict, @__MODULE__)))
-	# Check if we are inside a direct macroexpand code, and clean the LOAD_PATH if we do as we won't be executing the retured expression
-	is_macroexpand(stacktrace(), cell_id) && clean_loadpath(proj_file)
 	# We wrap the import expressions inside a try-catch, as those also correctly work from there.
 	# This also allow us to be able to catch the error in case something happens during loading and be able to gracefully clean the work space
 	text = "Reload $macroname"

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -132,10 +132,11 @@ end
 """
 	@frompackage target import_block
 
-This macro takes a local Package (derived from the `target` path), loads it as
-a submodule of the current Pluto workspace and then process the various
-import/using statements inside `import_block` to extract varables/functions from
-the local Package into the notebook workspace.
+This macro takes a local Package (derived from the `target` path, which can be
+an `AbstractString` or a `@raw_str`), loads it as a submodule of the current
+Pluto workspace and then process the various import/using statements inside
+`import_block` to extract varables/functions from the local Package into the
+notebook workspace.
 
 Its main use is allowing to load a local package under development within a
 running Pluto notebook in order to facilitate prototyping and testing.
@@ -160,9 +161,11 @@ See the package [documentation](https://disberd.github.io/PlutoDevMacros.jl/dev/
 
 See also: [`@fromparent`](@ref)
 """
-macro frompackage(target::String, ex)
+macro frompackage(target::Union{AbstractString, Expr}, ex)
+    target_file, valid = extract_raw_str(target)
+    @assert valid "Only `AbstractStrings` or `Exprs` of type `raw\"...\"` are allowed as `target` in the `@frompackage` macro."
 	calling_file = String(__source__.file)
-	out = _combined(ex, target, calling_file, __module__; macroname = "@frompackage")
+	out = _combined(ex, target_file, calling_file, __module__; macroname = "@frompackage")
 	esc(out)
 end
 

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -57,7 +57,7 @@ end
     @test valid
     @test str == "asd\\lol"
     @test_throws "Only `AbstractStrings`" Core.eval(Main, :(@frompackage 3+2 import *))
-    @test Core.eval(Main, :(@frompackage raw"asd\lol" import *)) === nothing
+    @test Core.eval(Main, :(@frompackage $(inpackage_target) import *)) === nothing
 end
 
 @testset "Outside Pluto" begin

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -49,15 +49,18 @@ finally
     Pkg.activate(current_project)
 end
 
+# Test the macroexpand part
+@test nothing === Core.eval(@__MODULE__, :(@macroexpand @frompackage $(inpackage_target) import *))
+@test_throws "No project was found" Core.eval(@__MODULE__, :(@macroexpand @frompackage "/asd/lol" import TOML))
 @testset "raw_str" begin
     str, valid = extract_raw_str("asd")
     @test valid
     @test str == "asd"
-    str, valid = extract_raw_str(raw"asd\lol")
+    str, valid = extract_raw_str(:(raw"asd\lol"))
     @test valid
     @test str == "asd\\lol"
     @test_throws "Only `AbstractStrings`" Core.eval(Main, :(@frompackage 3+2 import *))
-    @test Core.eval(Main, :(@frompackage $(inpackage_target) import *)) === nothing
+    @test Core.eval(@__MODULE__, :(@frompackage $(inpackage_target) import *)) === nothing
 end
 
 @testset "Outside Pluto" begin

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage
 import Pkg
 
 using Test

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -60,7 +60,9 @@ end
     @test valid
     @test str == "asd\\lol"
     @test_throws "Only `AbstractStrings`" Core.eval(Main, :(@frompackage 3+2 import *))
-    @test Core.eval(@__MODULE__, :(@frompackage $(inpackage_target) import *)) === nothing
+    cd(dirname(inpackage_target)) do
+        @test Core.eval(@__MODULE__, :(@frompackage raw".." import *)) === nothing
+    end
 end
 
 @testset "Outside Pluto" begin

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str
 import Pkg
 
 using Test
@@ -47,6 +47,16 @@ try
 end
 finally
     Pkg.activate(current_project)
+end
+
+@testset "raw_str" begin
+    str, valid = extract_raw_str("asd")
+    @test valid
+    @test str == "asd"
+    str, valid = extract_raw_str(raw"asd\lol")
+    @test valid
+    @test str == "asd\\lol"
+    @test_throws "Only `AbstractStrings`" Core.eval(Main, :(@frompackage 3+2 import *))
 end
 
 @testset "Outside Pluto" begin

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -57,6 +57,7 @@ end
     @test valid
     @test str == "asd\\lol"
     @test_throws "Only `AbstractStrings`" Core.eval(Main, :(@frompackage 3+2 import *))
+    @test Core.eval(Main, :(@frompackage raw"asd\lol" import *)) === nothing
 end
 
 @testset "Outside Pluto" begin


### PR DESCRIPTION
This PR removes a hanging call to the `clean_path` function which is not used anymore.
It also adds support for providing a `target` package to `@frompackage` using a `@raw_str` string literal