### PR TITLE
register target package as root_module [BREAKING]

### DIFF
--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -1,7 +1,31 @@
 import ..PlutoCombineHTL: make_html, make_script
 import ..PlutoDevMacros: hide_this_log
 
-get_temp_module() = fromparent_module[]
+function get_temp_module() 
+    @assert isassigned(fromparent_module) "You have to assing the parent module by calling `maybe_create_module` with a Pluto workspace module as input before you can use `get_temp_module`"
+    fromparent_module[]
+end
+
+# Extract the module that is the target in dict
+function get_target_module(dict)
+    mod_name = Symbol(dict["name"])
+    m = getfield(get_temp_module(), mod_name)
+    return m
+end
+
+function get_target_uuid(dict) 
+    uuid = get(dict, "uuid", nothing)
+    if !isnothing(uuid)
+        uuid = Base.UUID(uuid)
+    end
+    return uuid
+end
+
+function get_target_pkgid(dict)
+    mod_name = dict["name"]
+    uuid = get_target_uuid(dict)
+    Base.PkgId(uuid, mod_name)
+end
 
 #=
 We don't use manual rerun so we just comment this till after we can use it

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -81,6 +81,8 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 	end
 	# Now we add the call to maybe load the package extensions
 	push!(args, :($load_package_extensions($dict, @__MODULE__)))
+    # Register this module as root module. We need to this after trying to load the extensions
+    push!(args, :($register_target_module_as_root($dict)))
 	# We wrap the import expressions inside a try-catch, as those also correctly work from there.
 	# This also allow us to be able to catch the error in case something happens during loading and be able to gracefully clean the work space
 	text = "Reload $macroname"

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.38
+# v0.19.42
 
 using Markdown
 using InteractiveUtils
@@ -49,7 +49,7 @@ PlutoPlotly = "~0.4.4"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.1"
+julia_version = "1.10.3"
 manifest_format = "2.0"
 project_hash = "45c2663b0b08aa011df96ad7e600bf23da33df7e"
 
@@ -107,7 +107,7 @@ version = "0.12.10"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.0+0"
+version = "1.1.1+0"
 
 [[deps.Dates]]
 deps = ["Printf"]

--- a/test/TestPackage/out_notebook.jl
+++ b/test/TestPackage/out_notebook.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.36
+# v0.19.42
 
 using Markdown
 using InteractiveUtils
@@ -67,6 +67,9 @@ isdefined(TestPackage, :TEST_INIT) && TestPackage.TEST_INIT[] == 5 || error("The
 # ╔═╡ e37034a1-398c-45ad-803c-4b78e3388464
 isdefined(TestPackage.SUBINIT, :TEST_SUBINIT) && TestPackage.SUBINIT.TEST_SUBINIT[] == 15 || error("The execution of the __init__ function in the submodule did not seem to happen")
 
+# ╔═╡ 14a547ce-f48a-4f19-88f5-b2ca499fc087
+(pkgdir(TestPackage) === @__DIR__) || error("`pkgdir(TestPackage)` did not return the correct path, it seems like registering as root module failed")
+
 # ╔═╡ Cell order:
 # ╠═931a8c2c-ed76-11ed-3721-396dae146ad4
 # ╠═bd0d177f-ab66-493d-89a6-a9faca81cd11
@@ -81,3 +84,4 @@ isdefined(TestPackage.SUBINIT, :TEST_SUBINIT) && TestPackage.SUBINIT.TEST_SUBINI
 # ╠═3e83aab4-5feb-4f3f-9dc1-2da208bcd599
 # ╠═06408ada-f0b7-4057-9177-a79baf2fa9cf
 # ╠═e37034a1-398c-45ad-803c-4b78e3388464
+# ╠═14a547ce-f48a-4f19-88f5-b2ca499fc087


### PR DESCRIPTION
This PR registers the loaded target package as a `root_module` using `Base.register_root_module`.
This will make the various behaviors of the package and its types mirror more closely what happens outside of Pluto.

Fixes #45 

Considered breaking as it may break things expecting the target package to not be a root module