### PR TITLE
Make @include_using the default catch-all behavior

### DIFF
--- a/docs/src/frompackage/import_statements.md
+++ b/docs/src/frompackage/import_statements.md
@@ -106,14 +106,9 @@ If for example you had `using Base64` at the top of your module, to effectively 
     using >.Base64
 end
 ```
-This is now not strictly necessary anymore, as `@frompackage`/`@fromparent` now recognize the special macro `@include_using` during expansion. This macro is not actually defined in the package but tells the `@fromparent` call to also re-export names exposed by `using` statements when paired with a [Catch-all statement](#Catch-All).
-Since v0.7.3, you can re-export everything including names from `using` statements with the following:
+Since v0.8.0 of PlutoDevMacros, the automatic inclusion of names exposed via `using` statements is the default behavior when doing `catch-all` imports.
+If one wants to revert back to the previous version where only names effectively defined within the target module (or explicitly imported with `import OtherPackage: x`) would be brought into the Pluto module's scope, it is sufficient to prepend the `@exclude_using` macro to the _catch-all_ import statement like so:
 ```julia
-@fromparent @include_using import *
+@fromparent @exclude_using import *
 ```
 This statement can be used alone or coupled with other valid import statements within a `begin ... end` block.
-!!! note
-    Only a catch-all statement is supported after the `@include_using` macro.
-    \
-    \
-    For the moment this behavior is opt-in (via `@include_using`) to avoid a breaking change, but it will likely become the default catch-all behavior at the next breaking release.

--- a/src/PlutoDevMacros.jl
+++ b/src/PlutoDevMacros.jl
@@ -37,7 +37,6 @@ include("../notebooks/plutoinclude_macro.jl") # hasexpr, default_exprlist, inclu
 #                 logs.parentElement.style.display = "none"
 #             }
 #         </script>""")
-#         @info "GESU"
 #     else
         
 #     end

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -219,7 +219,7 @@ function filterednames_filter_func(m; excluded, caller_module, package_dict)
                     # We are just replacing the previous implementation of this call's target package, so we want to overwrite
                     return true
                 else
-                    @warn "Symbol $s is already defined in the caller module and points to a different object. Skipping"
+                    @warn "Symbol `:$s`, is already defined in the caller module and points to a different object. Skipping"
                 end
             end
             return false

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -188,7 +188,7 @@ end
 getfirst(itr) = getfirst(x -> true, itr)
 
 ## filterednames
-function filterednames(m::Module; all = true, imported = true, explicit_names = nothing)
+function filterednames(m::Module, caller_module = nothing; all = true, imported = true, explicit_names = nothing, package_dict = nothing)
 	excluded = (:eval, :include, :_fromparent_dict_, Symbol("@bind"))
     mod_names = names(m;all, imported)
     filter_args = if explicit_names isa Set{Symbol}
@@ -199,11 +199,35 @@ function filterednames(m::Module; all = true, imported = true, explicit_names = 
     else
         mod_names
     end
-	filter(filter_args) do s
-		Base.isgensym(s) && return false
-		s in excluded && return false
-		return true
-	end
+    filter_func = filterednames_filter_func(m; excluded, caller_module, package_dict)
+	filter(filter_func, filter_args)
+end
+
+function filterednames_filter_func(m; excluded, caller_module, package_dict)
+    f(s) = let excluded = excluded, caller_module = caller_module, package_dict = package_dict
+        Base.isgensym(s) && return false
+        s in excluded && return false
+        if caller_module isa Module
+            previous_target_module = get_stored_module(package_dict)
+            # We check and avoid putting in scope symbols which are already in the caller module
+            isdefined(caller_module, s) || return true
+            # Here we have to extract the symbols to compare them
+            mod_val = getfield(m, s)
+            caller_val = getfield(caller_module, s)
+            if caller_val !== mod_val 
+                if isdefined(previous_target_module, s) && caller_val === getfield(previous_target_module, s)
+                    # We are just replacing the previous implementation of this call's target package, so we want to overwrite
+                    return true
+                else
+                    @warn "Symbol $s is already defined in the caller module and points to a different object. Skipping"
+                end
+            end
+            return false
+        else # We don't check for names clashes with a caller module
+            return true
+        end
+    end
+    return f
 end
 
 
@@ -316,3 +340,8 @@ function register_target_module_as_root(dict)
         Base.set_pkgorigin_version_path(id, entry_point)
     end
 end
+
+# This function will get the module stored in the created_modules dict based on the entry point
+get_stored_module(dict) = get(created_modules, dict["file"], nothing)
+# This will store in it
+update_stored_module(dict) = created_modules[dict["file"]] = get_target_module(dict)

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -4,6 +4,8 @@ const fromparent_module = Ref{Module}()
 const macro_cell = Ref("undefined")
 const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
 
+const created_modules = Dict{String, Module}()
+
 struct PkgInfo 
 	name::Union{Nothing, String}
 	uuid::Base.UUID

--- a/test/TestPackage/src/inner_notebook2.jl
+++ b/test/TestPackage/src/inner_notebook2.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.25
+# v0.19.42
 
 using Markdown
 using InteractiveUtils

--- a/test/TestUsingNames/src/TestUsingNames.jl
+++ b/test/TestUsingNames/src/TestUsingNames.jl
@@ -4,6 +4,7 @@ using Base64
 
 export top_level_func
 top_level_func() = 1
+clash_name = 5
 
 module Test1
     using Example

--- a/test/TestUsingNames/test_notebook1.jl
+++ b/test/TestUsingNames/test_notebook1.jl
@@ -33,7 +33,7 @@ end
 
 # ╔═╡ 23a1bdef-5c31-4c90-a7f5-1f5a806d3d2e
 #=╠═╡
-@fromparent import *
+@fromparent @exclude_using import *
   ╠═╡ =#
 
 # ╔═╡ e4f436ed-27e9-4d19-98bd-c2b3021cf8bd

--- a/test/TestUsingNames/test_notebook2.jl
+++ b/test/TestUsingNames/test_notebook2.jl
@@ -33,7 +33,7 @@ end
 
 # ╔═╡ ac3d261a-86c9-453f-9d86-23a8f30ca583
 #=╠═╡
-@fromparent @include_using import *
+@fromparent import *
   ╠═╡ =#
 
 # ╔═╡ dd3f662f-e2ce-422d-a91a-487a4da359cc

--- a/test/TestUsingNames/test_notebook2.jl
+++ b/test/TestUsingNames/test_notebook2.jl
@@ -28,6 +28,8 @@ begin
 	end
 	using Main.Revise
 	using Main.PlutoDevMacros
+	# We defined a variable here that clashes with something in the target to show the warning
+	clash_name = 0
 end
   ╠═╡ =#
 
@@ -42,7 +44,13 @@ end
 isdefined(@__MODULE__, :base64encode) || error("base64encode from Base64 should be defined")
   ╠═╡ =#
 
+# ╔═╡ c72f2544-eb2e-4ed6-a89b-495ead20b5f6
+#=╠═╡
+clash_name === 0 || error("The clashed name was not handled correctly")
+  ╠═╡ =#
+
 # ╔═╡ Cell order:
 # ╠═4f8def86-f90b-4f74-ac47-93fe6e437cee
 # ╠═ac3d261a-86c9-453f-9d86-23a8f30ca583
 # ╠═dd3f662f-e2ce-422d-a91a-487a4da359cc
+# ╠═c72f2544-eb2e-4ed6-a89b-495ead20b5f6

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -101,7 +101,7 @@ srcdir = joinpath(@__DIR__, "../TestDevDependency/src/")
     SessionActions.shutdown(ss, nb)
 end
 
-# We test @include_using (issue 11)
+# We test @exclude_using (issue 11)
 srcdir = joinpath(@__DIR__, "../TestUsingNames/src/")
 @testset "Using Names" begin
     ss = ServerSession(; options)


### PR DESCRIPTION
This PR makes the use of `@include_using` obsolete as it becomes the default when doing a catchall-import (e.g. `@fromparent import *`).

It now adds an equivalent opt out fake macro `@exclude_using` to have the 0.7 behavior where all names brought into the target scope with `using` statements are not imported with catch-all.

As this is now by default re-exporting everything, this PR also added another step in the filtering process of names to import.
At the moment, whenever a name to be imported in the calling Pluto notebook is already defined (and not pointing to some value/function defined withint the previous version of the target package itself), it is skipped.
When there is a clash between a name to import an a name already existing in the caller module (which is tied to a different object than the one imported by the target package), a warning will be issued like below:
![image](https://github.com/disberd/PlutoDevMacros.jl/assets/12846528/c32e53bd-3607-483c-9330-dad66a9b6a4a)
