### PR TITLE
add target package as dev in active environment

### DIFF
--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -1,4 +1,4 @@
-using Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest, write_manifest
+using Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest, write_manifest, PackageSpec, VersionSpec, GitRepo
 
 @kwdef mutable struct EnvCacheGroup
     "This is the EnvCache of the environment added by @fromparent to the LOAD_PATH"
@@ -35,6 +35,16 @@ get_active(ecg::EnvCacheGroup) = ecg.active
 get_target(ecg::EnvCacheGroup) = ecg.target
 get_notebook(ecg::EnvCacheGroup) = ecg.notebook
 
+# This will create a package spec from the target project for adding the target package as `dev` in the active environment
+function target_packagespec(target::EnvCache)
+    (;name, uuid) = target.project
+    path = dirname(target.project_file)
+    repo = GitRepo(;source = path)
+    version = VersionSpec() # We are developing so we put an empty VersionSpec
+    PackageSpec(;name, uuid, version, path, repo)
+end
+
+# This will potentially update the target (or notebook) project the ECG is pointing to
 function maybe_update_envcache(projfile::String, ecg::EnvCacheGroup; notebook = false)
 	f = notebook ? get_notebook : get_target
 	env = f(ecg)
@@ -59,15 +69,16 @@ update_envcache!(::Nothing) = nothing
 function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 	c = Context(; io)
 	# Update the target and notebook ecg 
-	update_envcache!(ecg |> get_target)
+    target = ecg |> get_target
+	update_envcache!(target)
 	update_envcache!(ecg |> get_notebook)
 	active = get_active(ecg)
 	active_manifest = active |> get_manifest_file
 	active_project = active |> get_project_file
-	target_manifest = get_target(ecg) |> get_manifest_file
+	target_manifest = target |> get_manifest_file
 	if !isfile(target_manifest)
 		@info "It seems that the target package does not have a manifest file. Trying to instantiate its environment"
-		c.env = ecg.target
+		c.env = target
         Pkg.instantiate(c)
 	end
 	if !isfile(active_manifest) || !isfile(active_project)
@@ -75,7 +86,7 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 	end
 	if !force
 		active_mtime = mtime(active_manifest)
-		target_mtime = mtime(ecg |> get_target |> get_manifest_file)
+		target_mtime = mtime(target_manifest)
         # Force an update if the target manifest is newer
 		force = force || active_mtime < target_mtime
 	end
@@ -83,7 +94,7 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
         # This path will update the active Env by copying the project and manifest from the target
 		mkpath(dirname(active_manifest))
 		# We copy a reduced version of the project, only with deps, weakdeps and compat
-        pd = ecg.target.project.other
+        pd = target.project.other
         ad = Dict{String, Any}((k => pd[k] for k in ("deps", "compat", "weakdeps") if haskey(pd, k)))
         write_project(ad, active_project)
         # We copy the Manifest
@@ -91,7 +102,8 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
         # We call instantiate
 		update_envcache!(ecg.active)
 		c.env = ecg.active
-        Pkg.instantiate(c)
+        # We add the target package as `dev` in the active environment
+        Pkg.develop(c, [target_packagespec(target)])
     end
     return ecg
 end

--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -1,4 +1,4 @@
-using Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest, write_manifest, PackageSpec, VersionSpec, GitRepo
+using Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest, write_manifest,  Manifest, Project, PackageEntry
 
 @kwdef mutable struct EnvCacheGroup
     "This is the EnvCache of the environment added by @fromparent to the LOAD_PATH"
@@ -35,15 +35,6 @@ get_active(ecg::EnvCacheGroup) = ecg.active
 get_target(ecg::EnvCacheGroup) = ecg.target
 get_notebook(ecg::EnvCacheGroup) = ecg.notebook
 
-# This will create a package spec from the target project for adding the target package as `dev` in the active environment
-function target_packagespec(target::EnvCache)
-    (;name, uuid) = target.project
-    path = dirname(target.project_file)
-    repo = GitRepo(;source = path)
-    version = VersionSpec() # We are developing so we put an empty VersionSpec
-    PackageSpec(;name, uuid, version, path, repo)
-end
-
 # This will potentially update the target (or notebook) project the ECG is pointing to
 function maybe_update_envcache(projfile::String, ecg::EnvCacheGroup; notebook = false)
 	f = notebook ? get_notebook : get_target
@@ -58,6 +49,7 @@ function maybe_update_envcache(projfile::String, ecg::EnvCacheGroup; notebook = 
 	return nothing
 end
 
+default_context(; io = default_pkg_io[]) = Context(; io)
 
 function update_envcache!(e::EnvCache)
 	e.project = read_project(e.project_file)
@@ -66,8 +58,7 @@ function update_envcache!(e::EnvCache)
 end
 update_envcache!(::Nothing) = nothing
 # Update the active EnvCache by eventually copying reduced project and manifest from the package EnvCache
-function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
-	c = Context(; io)
+function update_ecg!(ecg::EnvCacheGroup; force = false, context = default_context())
 	# Update the target and notebook ecg 
     target = ecg |> get_target
 	update_envcache!(target)
@@ -78,8 +69,8 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
 	target_manifest = target |> get_manifest_file
 	if !isfile(target_manifest)
 		@info "It seems that the target package does not have a manifest file. Trying to instantiate its environment"
-		c.env = target
-        Pkg.instantiate(c)
+		context.env = target
+        Pkg.instantiate(context)
 	end
 	if !isfile(active_manifest) || !isfile(active_project)
 		force = true
@@ -90,22 +81,57 @@ function update_ecg!(ecg::EnvCacheGroup; force = false, io::IO = devnull)
         # Force an update if the target manifest is newer
 		force = force || active_mtime < target_mtime
 	end
-    if force
-        # This path will update the active Env by copying the project and manifest from the target
-		mkpath(dirname(active_manifest))
-		# We copy a reduced version of the project, only with deps, weakdeps and compat
-        pd = target.project.other
-        ad = Dict{String, Any}((k => pd[k] for k in ("deps", "compat", "weakdeps") if haskey(pd, k)))
-        write_project(ad, active_project)
-        # We copy the Manifest
-        copy_manifest(target_manifest, active_manifest)
-        # We call instantiate
-		update_envcache!(ecg.active)
-		c.env = ecg.active
-        # We add the target package as `dev` in the active environment
-        Pkg.develop(c, [target_packagespec(target)])
-    end
+    force && update_active_from_target!(ecg; context)
     return ecg
+end
+
+# This function will forcibly copy the target project/manifest to the active project/manifest. It will also add the target package as dev dependency to the active project/manifest. This will not rely on calling `Pkg.develop` directly as this will trigger pre-compilation and we are not really interested in precompiling the environment every time. This function assumes that the target environment is already instantiated
+function update_active_from_target!(ecg::EnvCacheGroup; context = default_context())
+    active = get_active(ecg)
+    target = get_target(ecg)
+    target_project = get_project(target)
+    # We create a deep copy of the project and manifest
+    project = active.project = let p = target_project
+        out = Project() # Initialize empty project
+        # Try to copy deps, compat, weakdeps and extensions from the target
+        for key in (:deps, :compat, :weakdeps, :exts)
+            target_val = getproperty(p, key)
+            isempty(target_val) && continue
+            setproperty!(out, key, deepcopy(target_val))
+        end
+        out
+    end
+    manifest = active.manifest = deepcopy(target.manifest)
+    # We make sure to make the path in the active manifest be absolute
+    target_dir = dirname(get_manifest_file(target))
+    for entry in values(manifest.deps)
+        path = entry.path
+        (path === nothing || isabspath(path)) && continue
+        # Make it absolute w.r.t to 
+        path = abspath(target_dir, path)
+        entry.path = path
+    end
+    # We now add the target package to the active env
+    @assert target_project.name !== nothing && target_project.uuid !== nothing "The project found at $(get_project_file(target)) is not a package, simple environments are currently not supported"
+    # Add the target within the project
+    project.deps[target_project.name] = target_project.uuid
+    target_pe = PackageEntry(;
+        name = target_project.name,
+        uuid = target_project.uuid,
+        path = target_dir,
+        version = target_project.version,
+        deps = deepcopy(target_project.deps),
+        weakdeps = deepcopy(target_project.weakdeps),
+        exts = deepcopy(target_project.exts),
+    )
+    manifest.deps[target_project.uuid] = target_pe
+    # We write the project and manifest
+    write_project(active)
+    write_manifest(active)
+    # We instantiate the active env
+    context.env = active
+    Pkg.resolve(context; update_registry = false)
+    Pkg.instantiate(context; update_registry = false, allow_build = false, allow_autoprecomp = false)
 end
 
 # Function to get the package dependencies from the manifest
@@ -120,23 +146,4 @@ function target_dependencies(target::EnvCache)
 		d[name] = PkgInfo(name, uuid, version)
 	end
 	direct, indirect
-end
-
-# This function will copy the manifest from the target environment to the active environment, taking care of making any relative path (i.e. for dev or added packages) absolute.
-function copy_manifest(target::AbstractString, active::AbstractString)
-    # We construct a TOML dict from the target manifest
-    raw_dict = TOML.parsefile(target)
-    deps = raw_dict["deps"]
-    for depval in values(deps)
-        for d in depval
-            path = get(d, "path", nothing)
-            isnothing(path) && continue
-            if !isabspath(path)
-                abs_path = abspath(dirname(target), path)
-                d["path"] = abs_path
-            end
-        end
-    end
-    write_manifest(raw_dict, active)
-    return nothing
 end

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -148,7 +148,6 @@ function get_package_data(packagepath::AbstractString)
 
 	maybe_update_envcache(project_file, ecg; notebook = false)
 	target = get_target(ecg)
-	isnothing(target.pkg) && error("The project found at $project_file is not a package, simple environments are currently not supported")
 	# We update the notebook and active envcaches to be up to date
 	update_ecg!(ecg)
 

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -1,5 +1,7 @@
 const _stdlibs = first.(values(Pkg.Types.stdlibs()))
 
+const default_pkg_io = Ref{IO}(devnull)
+
 const fromparent_module = Ref{Module}()
 const macro_cell = Ref("undefined")
 const manifest_names = ("JuliaManifest.toml", "Manifest.toml")

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -3,6 +3,8 @@ using Test
 
 import Pkg
 
+# FromPackage.default_pkg_io[] = Pkg.stderr_f()
+
 TestPackage_path = normpath(@__DIR__, "../TestPackage")
 # The LOAD_PATH hack is required because if we add ./TestPackage as a test dependency we get the error in https://github.com/JuliaLang/Pkg.jl/issues/1585
 push!(LOAD_PATH, TestPackage_path)


### PR DESCRIPTION
This PR will add the target package as `dev` dependency in the active environment handled by PlutoDevMacros.
This is not done by directly calling `Pkg.develop` as this will always recompile the environment.
Instead, after copying the target project and manifest in the active environment, the target package is added as dev dependency to the `Project` and `Manifest` objects (in the `project` and `manifest` field of the active `EnvCache`). 

As part of this PR, some internal functions have also been changed to update methodology.

This change should simplify locating the target package with `Base.locate_package_env` automatically, which will help with migrating to loading extensions with the standard approach using `Base` methods