### PR TITLE
refactor how extensions are loaded

### DIFF
--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -96,7 +96,7 @@ function update_active_from_target!(ecg::EnvCacheGroup; context = default_contex
         end
         out
     end
-    manifest = active.manifest = deepcopy(target.manifest)
+    manifest = active.manifest = deepcopy(target |> get_manifest)
     # We make sure to make the path in the active manifest be absolute
     target_dir = dirname(get_manifest_file(target))
     for entry in values(manifest.deps)

--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -17,11 +17,6 @@ function default_ecg()
 	return DEFAULT_ECG[]
 end
 
-function extensions_dir(env::EnvCache)
-	pkg = env.pkg
-	isnothing(pkg) && return nothing
-	ext_dir = joinpath(pkg.path, "ext")
-end
 get_manifest_file(e::EnvCache) = e.manifest_file
 get_project_file(e::EnvCache) = e.project_file
 get_manifest(e::EnvCache) = e.manifest

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -270,8 +270,6 @@ function get_extensions_ids(old_module::Module, parent::Base.PkgId)
     end
     return out
 end
-get_extensions_ids(::Nothing, ::Base.PkgId) = Base.PkgId[]
-
 
 # This function will register the target module for `dict` as a root module.
 # This relies on Base internals (and even the C API) but will allow make the loaded module behave more like if we simply did `using TargetPackage` in the REPL

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -171,9 +171,8 @@ function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	_MODULE_ = maybe_create_module(caller_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
-	proj_file = ecg |> get_active |> get_project_file
 	# We inject the project in the LOAD_PATH if it is not present already
-	add_loadpath(proj_file)
+	add_loadpath(ecg)
     # We start by loading each of the direct dependencies in the LoadedModules submodule
     load_direct_deps(package_dict, _MODULE_)
 	# We try evaluating the expression within the custom module

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -188,18 +188,7 @@ function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	__module = getfield(_MODULE_, mod_name)
 	# We put the dict inside the loaded module
 	Core.eval(__module, :(_fromparent_dict_ = $package_dict))
-	# @info block, __module
+    # Register this module as root module. 
+    register_target_module_as_root(package_dict)
 	return package_dict
-end
-
-function load_package_extensions(package_dict::Dict, caller_module::Module)
-	mod_name = package_dict["name"] |> Symbol
-	package_module = getfield(maybe_create_module(caller_module), mod_name)
-	load_package_extensions(package_module, package_dict)
-end
-function load_package_extensions(package_module::Module, package_dict::Dict)
-	add_loadpath(default_ecg())
-	# We try to reload 
-	maybe_add_extensions!(package_module, package_dict)
-	nothing
 end

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -79,12 +79,10 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 		arg isa LineNumberNode && continue
 		push!(args, parseinput(arg, package_dict; caller_module))
 	end
-    # We add this module to the created_modules dict
-    created_modules[package_dict["file"]] = get_target_module(package_dict)
-	# Now we add the call to maybe load the package extensions
-	push!(args, :($load_package_extensions($package_dict, @__MODULE__)))
-    # Register this module as root module. We need to this after trying to load the extensions
-    push!(args, :($register_target_module_as_root($package_dict)))
+    # We update th stored root module
+    update_stored_module(package_dict)
+    # We call at runtime the function to trigger extensions loading
+    push!(args, :($try_load_extensions($package_dict)))
 	# We wrap the import expressions inside a try-catch, as those also correctly work from there.
 	# This also allow us to be able to catch the error in case something happens during loading and be able to gracefully clean the work space
 	text = "Reload $macroname"

--- a/test/TestDirectExtension/Project.toml
+++ b/test/TestDirectExtension/Project.toml
@@ -13,6 +13,7 @@ PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 [extensions]
 Magic = "Example"
 PlotlyBaseExt = "PlotlyBase"
+DualDepsExt = ["PlotlyBase", "Example"]
 
 [compat]
 PlotlyBase = "0.8"

--- a/test/TestDirectExtension/ext/DualDepsExt.jl
+++ b/test/TestDirectExtension/ext/DualDepsExt.jl
@@ -1,0 +1,7 @@
+module DualDepsExt
+    import Example
+    import PlotlyBase
+    import TestDirectExtension
+
+    TestDirectExtension.to_extend(::Tuple{typeof(Example.hello), PlotlyBase.Plot}) = "Dual Deps Extension works!"
+end

--- a/test/TestDirectExtension/test_extension.jl
+++ b/test/TestDirectExtension/test_extension.jl
@@ -29,8 +29,17 @@ standard_extension_output = to_extend(plot(rand(4)).Plot)
 # ╔═╡ 8e7563ce-d2ba-4356-93e4-70ebe0f2be87
 weird_extension_output = to_extend(Example)
 
+# ╔═╡ 8d561235-2003-4446-bd64-b7f235d653a4
+standard_extension_output === "Standard Extension works!" || error("PlotlyBase extension did not load")
+
+# ╔═╡ 6f258d3c-7c09-4009-ad8d-001dbd451ad2
+weird_extension_output === "Weird Extension name works!" || error("Example extension did not load")
+
 # ╔═╡ da703251-1f4a-4fa1-ba08-720bceb2ada6
 p = plot_this()
+
+# ╔═╡ 1e143a84-1a79-448b-a7ff-189ef167870d
+to_extend((hello, p.Plot)) === "Dual Deps Extension works!" || error("dual deps extension failed")
 
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """
@@ -399,6 +408,9 @@ version = "17.4.0+2"
 # ╠═b93cdd74-1c65-4d15-a6e3-6c1855e37cce
 # ╠═675230da-e628-4059-b44d-6137a4dd4987
 # ╠═8e7563ce-d2ba-4356-93e4-70ebe0f2be87
+# ╠═8d561235-2003-4446-bd64-b7f235d653a4
+# ╠═6f258d3c-7c09-4009-ad8d-001dbd451ad2
+# ╠═1e143a84-1a79-448b-a7ff-189ef167870d
 # ╠═da703251-1f4a-4fa1-ba08-720bceb2ada6
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002


### PR DESCRIPTION
This PR changes how extensions are loaded for target packages.

Since #50, we now have our target package loaded as root_module, which gives access to some more convenience functionality from Base.

Prior to this PR, the extensions code was parsed and loaded in the target module with custom functions defined in the package.

Now, the extensions are loaded by calling `Base.insert_extension_triggers` and `Base.run_extension_callbacks`.
To allow reloading extensions upon manual reload, we `hackily` remove the loaded extension from `Base.EXT_PRIMED` and from `Base.loaded_modules` so that it can be re-inserted by `Base.run_extension_callbacks`.

This should now support all the extensions functionality from julia itself, closing #39 