### PR TITLE
add settings handling

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,7 @@ makedocs(;
             "Skipping Package Parts" => "frompackage/skipping_parts.md",
             "Use with PlutoPkg" => "frompackage/use_with_plutopkg.md",
             "Package Extensions" => "frompackage/package_extensions.md",
+            "Custom Settings" => "frompackage/custom_settings.md",
         ],
         "Other Exports" => "other_functions.md",
         # "PlutoHTLCombine" => "htl_combine.md",

--- a/docs/src/frompackage/custom_settings.md
+++ b/docs/src/frompackage/custom_settings.md
@@ -20,4 +20,8 @@ end
 Only assignments are supported inside the `@settings` block and only primitive values can be used as `val`, i.e. anything that is parsed as an `Expr` as macro argument is not a valid `val`.
 
 These are the supported settings:
-- `SHOULD_PREPEND_LOAD_PATH::Bool`: Defaults to `false`. This specifies whether the active environment added to the `LOAD_PATH` by the macro should go to the end or to the front of the `LOAD_PATH`. In some cases it can be useful to have the custom environment at the beginning of the LOAD_PATH for the purpose of locating packages.
+
+## `SHOULD_PREPEND_LOAD_PATH`
+`Bool` value that **defaults to `false`**. 
+
+This specifies whether the active environment added to the `LOAD_PATH` by the macro should go to the end or to the front of the `LOAD_PATH`. In some cases it can be useful to have the custom environment at the beginning of the LOAD_PATH for the purpose of locating packages.

--- a/docs/src/frompackage/custom_settings.md
+++ b/docs/src/frompackage/custom_settings.md
@@ -1,0 +1,23 @@
+# Customize Macro Settings
+The macro also allows to override default settings similar to how one skip lines in the package, using a custom `@settings` block as:
+```julia
+@fromparent begin
+    @settings setting1 = val1 setting2 = val2
+    import *
+end
+```
+or alternatively: 
+```julia
+@fromparent begin
+    @settings begin
+        setting1 = val1
+        setting2 = val2
+    end
+    import *
+end
+```
+
+Only assignments are supported inside the `@settings` block and only primitive values can be used as `val`, i.e. anything that is parsed as an `Expr` as macro argument is not a valid `val`.
+
+These are the supported settings:
+- `SHOULD_PREPEND_LOAD_PATH::Bool`: Defaults to `false`. This specifies whether the active environment added to the `LOAD_PATH` by the macro should go to the end or to the front of the `LOAD_PATH`. In some cases it can be useful to have the custom environment at the beginning of the LOAD_PATH for the purpose of locating packages.

--- a/src/frompackage/FromPackage.jl
+++ b/src/frompackage/FromPackage.jl
@@ -6,6 +6,7 @@ module FromPackage
     export @fromparent, @addmethod, @frompackage
 
     include("types.jl")
+    include("settings.jl")
     include("envcachegroup.jl")
     include("helpers.jl")
     include("code_parsing.jl")

--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -87,9 +87,11 @@ function update_active_from_target!(ecg::EnvCacheGroup; context = default_contex
     target_project = get_project(target)
     # We create a deep copy of the project and manifest
     project = active.project = let p = target_project
-        out = Project() # Initialize empty project
+        # We create a generator to copy the parts of the raw dict we are interested in, see https://github.com/disberd/PlutoDevMacros.jl/issues/57
+        raw = (k => p.other[k] for k in ("deps", "weakdeps", "compat") if haskey(p.other,k)) |> Dict
+        out = Project(raw) # Initialize empty project
         # Try to copy deps, compat, weakdeps and extensions from the target
-        for key in (:deps, :compat, :weakdeps, :exts)
+        for key in (:deps, :weakdeps, :compat)
             target_val = getproperty(p, key)
             isempty(target_val) && continue
             setproperty!(out, key, deepcopy(target_val))

--- a/src/frompackage/envcachegroup.jl
+++ b/src/frompackage/envcachegroup.jl
@@ -2,7 +2,7 @@ using Pkg.Types: EnvCache, write_project, Context, read_project, read_manifest, 
 
 @kwdef mutable struct EnvCacheGroup
     "This is the EnvCache of the environment added by @fromparent to the LOAD_PATH"
-    active::EnvCache = EnvCache(mktempdir())
+    active::EnvCache = EnvCache(mktempdir(;prefix = "frompackage_"))
     "This is the environment of the target of @fromparent"
     target::Union{Nothing, EnvCache} = nothing
     "This is the environment of the notebook calling @fromparent"
@@ -87,7 +87,7 @@ function update_active_from_target!(ecg::EnvCacheGroup; context = default_contex
     target_project = get_project(target)
     # We create a deep copy of the project and manifest
     project = active.project = let p = target_project
-        # We create a generator to copy the parts of the raw dict we are interested in, see https://github.com/disberd/PlutoDevMacros.jl/issues/57
+        # We create a generator to copy the parts of the raw dict we are interested in.
         raw = (k => p.other[k] for k in ("deps", "weakdeps", "compat") if haskey(p.other,k)) |> Dict
         out = Project(raw) # Initialize empty project
         # Try to copy deps, compat, weakdeps and extensions from the target

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -54,11 +54,16 @@ end
 =#
 
 # Functions to add and remove from the LOAD_PATH
-function add_loadpath(entry::String)
-	entry ∈ LOAD_PATH || push!(LOAD_PATH, entry)
-	return nothing
+function add_loadpath(entry::String; should_prepend)
+    idx = findfirst(==(entry), LOAD_PATH)
+    if isnothing(idx)
+        f! = should_prepend ? pushfirst! : push!
+        # We add
+        f!(LOAD_PATH, entry)
+    end
+    return nothing
 end
-add_loadpath(ecg::EnvCacheGroup) = add_loadpath(ecg |> get_active |> get_project_file)
+add_loadpath(ecg::EnvCacheGroup; kwargs...) = add_loadpath(ecg |> get_active |> get_project_file; kwargs...)
 
 ## execute only in notebook
 # We have to create our own simple check to only execute some stuff inside the notebook where they are defined. We have stuff in basics.jl but we don't want to include that in this notebook

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -41,7 +41,8 @@ function parse_settings(ex, dict)
         custom_settings = get!(Dict{Symbol, Any}, dict, "Custom Settings")
         k,v = arg.args
         @assert !(v isa Expr) "Only primitive values are allowed as values in the `@settings` block"
-        custom_settings[k] = v
+        name = Settings.setting_name(k)
+        custom_settings[name] = v
     end
 end
 

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -172,7 +172,7 @@ function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
 	# We inject the project in the LOAD_PATH if it is not present already
-	add_loadpath(ecg; should_prepend = get_setting(package_dict, :SHOULD_PREPEND_LOAD_PATH))
+	add_loadpath(ecg; should_prepend = Settings.get_setting(package_dict, :SHOULD_PREPEND_LOAD_PATH))
     # We start by loading each of the direct dependencies in the LoadedModules submodule
     load_direct_deps(package_dict, _MODULE_)
 	# We try evaluating the expression within the custom module

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -172,7 +172,7 @@ function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
 	# We reset the module path in case it was not cleaned
 	mod_name = mod_exp.args[2]
 	# We inject the project in the LOAD_PATH if it is not present already
-	add_loadpath(ecg)
+	add_loadpath(ecg; should_prepend = get_setting(package_dict, :SHOULD_PREPEND_LOAD_PATH))
     # We start by loading each of the direct dependencies in the LoadedModules submodule
     load_direct_deps(package_dict, _MODULE_)
 	# We try evaluating the expression within the custom module

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -58,6 +58,8 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 		dict = get_package_data(target_file)
 		# We try to extract eventual lines to skip
 		process_skiplines!(ex, dict)
+        # We extract and process custom settings
+		process_settings!(ex, dict)
 		load_module_in_caller(dict, caller_module)
 	else
 		error("Multiple Calls: The $macroname is already present in cell with id $(macro_cell[]), you can only have one call-site per notebook")

--- a/src/frompackage/settings.jl
+++ b/src/frompackage/settings.jl
@@ -1,0 +1,11 @@
+const SHOULD_PREPEND_LOAD_PATH = Ref(false)
+
+function get_setting(dict, name)
+    custom_settings = get(dict, "Custom Settings", nothing)
+    f() = get_setting(name)
+    isnothing(custom_settings) ? f() : get(f, custom_settings, name)
+end
+function get_setting(name::Symbol)
+    name === :SHOULD_PREPEND_LOAD_PATH && return SHOULD_PREPEND_LOAD_PATH[]
+    error("The setting $name is not a valid setting")
+end

--- a/src/frompackage/settings.jl
+++ b/src/frompackage/settings.jl
@@ -1,11 +1,64 @@
-const SHOULD_PREPEND_LOAD_PATH = Ref(false)
+module Settings
+    const SETTINGS_DEFAULTS = Dict{Symbol,Any}()
+    const SETTINGS_SYNONYMS = Dict{Symbol,Set{Symbol}}()
 
-function get_setting(dict, name)
-    custom_settings = get(dict, "Custom Settings", nothing)
-    f() = get_setting(name)
-    isnothing(custom_settings) ? f() : get(f, custom_settings, name)
-end
-function get_setting(name::Symbol)
-    name === :SHOULD_PREPEND_LOAD_PATH && return SHOULD_PREPEND_LOAD_PATH[]
-    error("The setting $name is not a valid setting")
+    # Add and remove
+    function add_setting(name::Symbol, default, synonyms=(name,))
+        @nospecialize
+        SETTINGS_DEFAULTS[name] = default
+        set = Set{Symbol}(synonyms)
+        push!(set, name)
+        SETTINGS_SYNONYMS[name] = set
+        return nothing
+    end
+    function remove_setting(name::Symbol)
+        if name in keys(SETTINGS_DEFAULTS)
+            delete!(SETTINGS_DEFAULTS, name)
+            delete!(SETTINGS_SYNONYMS, name)
+        else
+            @warn "The name `$name` is not associated to any valid setting. Nothing was removed."
+        end
+    end
+
+    function custom_error_msg(name) 
+        msg = "The name `$name` is not associated to any valid setting. Here are the valid settings and their allowed synonyms:\n"
+        for (k, v) in SETTINGS_SYNONYMS
+            msg *= "$k: ("
+            first = true
+            for n in v
+                if first
+                    msg *= "$n"
+                    first = false
+                else
+                    msg *= ", $n"
+                end
+            end
+            msg *= ")\n"
+        end
+        return msg
+    end
+
+    function setting_name(name)
+        for (k, v) in SETTINGS_SYNONYMS
+            name in v && return k
+        end
+        msg = custom_error_msg(name)
+        error(msg)
+    end
+
+    function get_setting(dict, name)
+        custom_settings = get(dict, "Custom Settings", nothing)
+        f() = get_setting(name)
+        isnothing(custom_settings) ? f() : get(f, custom_settings, name)
+    end
+    function get_setting(name::Symbol)
+        get(SETTINGS_DEFAULTS, name) do
+            msg = custom_error_msg(name)
+            error(msg)
+        end
+    end
+
+    function __init__()
+        add_setting(:SHOULD_PREPEND_LOAD_PATH, false, (:should_prepend_load_path, :prepend, :prepend_load_path))
+    end
 end

--- a/src/frompackage/settings.jl
+++ b/src/frompackage/settings.jl
@@ -58,7 +58,5 @@ module Settings
         end
     end
 
-    function __init__()
-        add_setting(:SHOULD_PREPEND_LOAD_PATH, false, (:should_prepend_load_path, :prepend, :prepend_load_path))
-    end
+    add_setting(:SHOULD_PREPEND_LOAD_PATH, false, (:should_prepend_load_path, :prepend, :prepend_load_path))
 end

--- a/test/TestDirectExtension/Project.toml
+++ b/test/TestDirectExtension/Project.toml
@@ -11,9 +11,9 @@ Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 
 [extensions]
+DualDepsExt = ["PlotlyBase", "Example"]
 Magic = "Example"
 PlotlyBaseExt = "PlotlyBase"
-DualDepsExt = ["PlotlyBase", "Example"]
 
 [compat]
 PlotlyBase = "0.8"

--- a/test/TestDirectExtension/ext/PlotlyBaseExt.jl
+++ b/test/TestDirectExtension/ext/PlotlyBaseExt.jl
@@ -1,7 +1,7 @@
 module PlotlyBaseExt
     using PlotlyBase
-    using PlotlyExtensionsHelper
     using TestDirectExtension
+    using TestDirectExtension.PlotlyExtensionsHelper
 
     TestDirectExtension.to_extend(p::Plot) = "Standard Extension works!"
     TestDirectExtension.plot_this() = plotly_plot(rand(10,4))

--- a/test/TestDirectExtension/src/TestDirectExtension.jl
+++ b/test/TestDirectExtension/src/TestDirectExtension.jl
@@ -1,5 +1,7 @@
 module TestDirectExtension
 
+using PlotlyExtensionsHelper
+
 export to_extend, plot_this
 
 to_extend(x) = "Generic Method"

--- a/test/frompackage/settings.jl
+++ b/test/frompackage/settings.jl
@@ -63,6 +63,10 @@ end
 
 @testset "SHOULD_PREPEND_LOAD_PATH" begin
     proj_file = FromPackage.default_ecg() |> get_active |> get_project_file
+    # Remove the custom envs from the load path
+    filter!(LOAD_PATH) do proj
+        startswith(proj, joinpath(tempdir(), "frompackage_"))
+    end
     l = length(LOAD_PATH)
     @test proj_file ∉ LOAD_PATH
     add_loadpath(proj_file; should_prepend = false)

--- a/test/frompackage/settings.jl
+++ b/test/frompackage/settings.jl
@@ -65,17 +65,20 @@ end
     proj_file = FromPackage.default_ecg() |> get_active |> get_project_file
     # Remove the custom envs from the load path
     filter!(LOAD_PATH) do proj
-        startswith(proj, joinpath(tempdir(), "frompackage_"))
+        !startswith(proj |> dirname |> basename, "frompackage_")
     end
+    @info LOAD_PATH
     l = length(LOAD_PATH)
     @test proj_file ∉ LOAD_PATH
     add_loadpath(proj_file; should_prepend = false)
     @test length(LOAD_PATH) == l+1
     add_loadpath(proj_file; should_prepend = false)
     @test length(LOAD_PATH) == l+1
-    @test pop!(LOAD_PATH) == proj_file
-    
+    @test LOAD_PATH[end] == proj_file
+    LOAD_PATH[end] == proj_file && pop!(LOAD_PATH)
+
     # Prepend
     add_loadpath(proj_file; should_prepend = true)
-    @test popfirst!(LOAD_PATH) == proj_file
+    @test LOAD_PATH[1] == proj_file
+    LOAD_PATH[1] == proj_file && popfirst!(LOAD_PATH)
 end

--- a/test/frompackage/settings.jl
+++ b/test/frompackage/settings.jl
@@ -8,7 +8,21 @@ target = TestPackage_path
 # We test that the prefix is there in the temp env
 @test startswith(FromPackage.default_ecg() |> get_active |> get_project_file |> dirname |> basename, "frompackage_")
 
-@test_throws "is not a valid setting" get_setting(:asdfasdf)
+@testset "Get Setting" begin
+    @test_throws "is not a valid setting" get_setting(:asdfasdf)
+    key = :SHOULD_PREPEND_LOAD_PATH
+    current = getproperty(FromPackage, key)[]
+    @test get_setting(key) === current
+
+    getproperty(FromPackage, key)[] = !current
+    @test get_setting(key) === !current
+
+    getproperty(FromPackage, key)[] = current
+    @test get_setting(key) === current
+    # Test with dict
+    d = Dict("Custom Settings" => Dict(key => !current))
+    @test get_setting(d, key) === !current
+end
 
 @testset "Parsing" begin
     ex = :(@settings a = 1)

--- a/test/frompackage/settings.jl
+++ b/test/frompackage/settings.jl
@@ -1,0 +1,63 @@
+import PlutoDevMacros.FromPackage: FromPackage, add_loadpath, process_settings!, get_setting, get_active, get_project_file
+using Test
+
+TestPackage_path = normpath(@__DIR__, "../TestPackage")
+# We point at the helpers file inside the TestPackage module, we stuff up to the first include
+target = TestPackage_path
+
+# We test that the prefix is there in the temp env
+@test startswith(FromPackage.default_ecg() |> get_active |> get_project_file |> dirname |> basename, "frompackage_")
+
+@test_throws "is not a valid setting" get_setting(:asdfasdf)
+
+@testset "Parsing" begin
+    ex = :(@settings a = 1)
+    # Nothing done without block, as that is anyhow not supported
+    @test ex === process_settings!(ex, Dict())
+    # Test that settings are removed if in a block
+    ex = quote $ex end
+    d = Dict()
+    new_ex = process_settings!(deepcopy(ex), d) |> Base.remove_linenums!
+    @test isempty(new_ex.args)
+    @test haskey(d, "Custom Settings")
+    @test d["Custom Settings"][:a] == 1
+
+    # We check illegal expressions
+    ex = quote
+        @settings a = 1 b = rand()
+    end
+    @test_throws "Only primitive" process_settings!(deepcopy(ex), Dict())
+    ex = quote
+        @settings a = 1 b c
+    end
+    @test_throws "Only `var = value`" process_settings!(deepcopy(ex), Dict())
+
+    # Test the begin end synthax
+    ex = quote
+        @settings begin
+            a = 1
+            b = 2
+        end
+    end
+    d = Dict()
+    new_ex = process_settings!(deepcopy(ex), d) |> Base.remove_linenums!
+    @test isempty(new_ex.args)
+    @test haskey(d, "Custom Settings")
+    @test d["Custom Settings"][:a] == 1
+    @test d["Custom Settings"][:b] == 2
+end
+
+@testset "SHOULD_PREPEND_LOAD_PATH" begin
+    proj_file = FromPackage.default_ecg() |> get_active |> get_project_file
+    l = length(LOAD_PATH)
+    @test proj_file ∉ LOAD_PATH
+    add_loadpath(proj_file; should_prepend = false)
+    @test length(LOAD_PATH) == l+1
+    add_loadpath(proj_file; should_prepend = false)
+    @test length(LOAD_PATH) == l+1
+    @test pop!(LOAD_PATH) == proj_file
+    
+    # Prepend
+    add_loadpath(proj_file; should_prepend = true)
+    @test popfirst!(LOAD_PATH) == proj_file
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,6 @@ Aqua.test_all(PlutoDevMacros)
 
 @safetestset "Basics" begin include("basics.jl") end
 @safetestset "@frompackage: basics" begin include("frompackage/basics.jl") end
+@safetestset "@frompackage: settings" begin include("frompackage/settings.jl") end
 @safetestset "@frompackage: with Pluto Session" begin include("frompackage/with_pluto_session.jl") end
 @safetestset "@frompackage: Package Extensions in Pluto" begin include("frompackage/pluto_package_extensions.jl") end


### PR DESCRIPTION
This PR cleans up some previous mistakes in implementation, making extension handling hopefully more robust.
It closes #57.

It also adds a new functionality to parse custom settings for modifying the macro behavior.
Similarly to `@skiplines`, these are parsed from the input expression provided.

For the time being, only the setting `SHOULD_PREPEND_LOAD_PATH` is supported