### PR TITLE
simplify and fix intermittent names import

### DIFF
--- a/src/frompackage/code_parsing.jl
+++ b/src/frompackage/code_parsing.jl
@@ -67,7 +67,7 @@ function modify_package_using!(ex::Expr, loc, package_dict::Dict, eval_module::M
         extracted_package_name = first(package_expr_args)
         if extracted_package_name === package_name
             # We modify the specific using expression to point to the correct module path
-            prepend!(package_expr_args, modname_path(fromparent_module[]))
+            prepend!(package_expr_args, modname_path(get_temp_module()))
         end
     end
     return true

--- a/src/frompackage/code_parsing.jl
+++ b/src/frompackage/code_parsing.jl
@@ -67,7 +67,7 @@ function modify_package_using!(ex::Expr, loc, package_dict::Dict, eval_module::M
         extracted_package_name = first(package_expr_args)
         if extracted_package_name === package_name
             # We modify the specific using expression to point to the correct module path
-            prepend!(package_expr_args, modname_path(get_temp_module()))
+            prepend!(package_expr_args, temp_module_path())
         end
     end
     return true

--- a/src/frompackage/helpers.jl
+++ b/src/frompackage/helpers.jl
@@ -325,8 +325,10 @@ function update_stored_module(package_dict::Dict)
     update_stored_module(m)
 end
 
-function overwrite_imported_symbols(package_dict)
+overwrite_imported_symbols(package_dict::Dict) = overwrite_imported_symbols(get(Set{Symbol}, package_dict, "Imported Symbols"))
+# This overwrites the PREVIOUSLY_IMPORTED_SYMBOLS with the contents of new_symbols
+function overwrite_imported_symbols(new_symbols)
     empty!(PREVIOUSLY_IMPORTED_NAMES)
-    union!(PREVIOUSLY_IMPORTED_NAMES, package_dict["Imported Symbols"])
+    union!(PREVIOUSLY_IMPORTED_NAMES, new_symbols)
     nothing
 end

--- a/src/frompackage/input_parsing.jl
+++ b/src/frompackage/input_parsing.jl
@@ -338,7 +338,7 @@ function parseinput(ex, package_dict; caller_module)
     end
 	imported_names = filterednames(_mod; all = catchall, imported = catchall, explicit_names, caller_module)
     # We add the imported names to the set for tracking names imported by this macrocall
-    union!(get!(Set{Symbol}, package_dict, "Imported Symbols"), imported_names)
+    union!(get!(Set{Symbol}, package_dict, "Catchall Imported Symbols"), imported_names)
 	# At this point we have all the names and we just have to create the final expression
 	importednames_exprs = map(n -> Expr(:., n), imported_names)
 	return reconstruct_import_expr(modname_expr, importednames_exprs)

--- a/src/frompackage/loading.jl
+++ b/src/frompackage/loading.jl
@@ -174,7 +174,7 @@ function load_module_in_caller(mod_exp::Expr, package_dict::Dict, caller_module)
     stored_module = get_stored_module()
     if !isnothing(stored_module) && nameof(stored_module) !== mod_name
         # We reset the list of previous symbols
-        empty!(PREVIOUSLY_IMPORTED_NAMES)
+        empty!(PREVIOUS_CATCHALL_NAMES)
     end
 	# We inject the project in the LOAD_PATH if it is not present already
 	add_loadpath(ecg; should_prepend = Settings.get_setting(package_dict, :SHOULD_PREPEND_LOAD_PATH))

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -83,7 +83,7 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 	end
     # We update th stored root module
     update_stored_module(package_dict)
-    # We put the included names in PREVIOUSLY_IMPORTED_NAMES
+    # We put the included names in PREVIOUS_CATCHALL_NAMES
     overwrite_imported_symbols(package_dict)
     # We call at runtime the function to trigger extensions loading
     push!(args, :($try_load_extensions($package_dict)))

--- a/src/frompackage/macro.jl
+++ b/src/frompackage/macro.jl
@@ -83,6 +83,8 @@ function frompackage(ex, target_file, caller, caller_module; macroname)
 	end
     # We update th stored root module
     update_stored_module(package_dict)
+    # We put the included names in PREVIOUSLY_IMPORTED_NAMES
+    overwrite_imported_symbols(package_dict)
     # We call at runtime the function to trigger extensions loading
     push!(args, :($try_load_extensions($package_dict)))
 	# We wrap the import expressions inside a try-catch, as those also correctly work from there.

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -4,7 +4,7 @@ const default_pkg_io = Ref{IO}(devnull)
 
 const TEMP_MODULE_NAME = :_FromPackage_TempModule_
 const STORED_MODULE = Ref{Union{Module, Nothing}}(nothing)
-const PREVIOUSLY_IMPORTED_NAMES = Set{Symbol}()
+const PREVIOUS_CATCHALL_NAMES = Set{Symbol}()
 const macro_cell = Ref("undefined")
 const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
 

--- a/src/frompackage/types.jl
+++ b/src/frompackage/types.jl
@@ -2,7 +2,9 @@ const _stdlibs = first.(values(Pkg.Types.stdlibs()))
 
 const default_pkg_io = Ref{IO}(devnull)
 
-const fromparent_module = Ref{Module}()
+const TEMP_MODULE_NAME = :_FromPackage_TempModule_
+const STORED_MODULE = Ref{Union{Module, Nothing}}(nothing)
+const PREVIOUSLY_IMPORTED_NAMES = Set{Symbol}()
 const macro_cell = Ref("undefined")
 const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
 

--- a/test/TestUsingNames/src/TestUsingNames.jl
+++ b/test/TestUsingNames/src/TestUsingNames.jl
@@ -5,6 +5,7 @@ using Base64
 export top_level_func
 top_level_func() = 1
 clash_name = 5
+rand_variable = rand()
 
 module Test1
     using Example

--- a/test/TestUsingNames/test_notebook2.jl
+++ b/test/TestUsingNames/test_notebook2.jl
@@ -49,8 +49,14 @@ isdefined(@__MODULE__, :base64encode) || error("base64encode from Base64 should 
 clash_name === 0 || error("The clashed name was not handled correctly")
   ╠═╡ =#
 
+# ╔═╡ 4492d516-2b23-45b7-bf76-7458e7352fea
+#=╠═╡
+rand_variable # This should change at every re-run
+  ╠═╡ =#
+
 # ╔═╡ Cell order:
 # ╠═4f8def86-f90b-4f74-ac47-93fe6e437cee
 # ╠═ac3d261a-86c9-453f-9d86-23a8f30ca583
 # ╠═dd3f662f-e2ce-422d-a91a-487a4da359cc
 # ╠═c72f2544-eb2e-4ed6-a89b-495ead20b5f6
+# ╠═4492d516-2b23-45b7-bf76-7458e7352fea

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -194,7 +194,7 @@ end
             f(ex) = parseinput(deepcopy(ex), dict; caller_module)
 
 
-            parent_path = temp_module_path()
+            parent_path = temp_module_path() |> collect
             # FromDeps imports
             ex = :(using >.BenchmarkTools)
 
@@ -264,7 +264,7 @@ end
             caller_module = Module(gensym())
             dict = load_module_in_caller(inpluto_caller, caller_module)
             f(ex) = parseinput(deepcopy(ex), dict; caller_module)
-            parent_path = temp_module_path()
+            parent_path = temp_module_path() |> collect
 
             ex = :(import PackageModule.Issue2)
             expected = :(import $(parent_path...).TestPackage.Issue2)

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage, can_import_in_caller, overwrite_imported_symbols
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, temp_module_path, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage, can_import_in_caller, overwrite_imported_symbols
 using Test
 
 import Pkg
@@ -194,7 +194,7 @@ end
             f(ex) = parseinput(deepcopy(ex), dict; caller_module)
 
 
-            parent_path = modname_path(get_temp_module())
+            parent_path = temp_module_path()
             # FromDeps imports
             ex = :(using >.BenchmarkTools)
 
@@ -264,7 +264,7 @@ end
             caller_module = Module(gensym())
             dict = load_module_in_caller(inpluto_caller, caller_module)
             f(ex) = parseinput(deepcopy(ex), dict; caller_module)
-            parent_path = modname_path(get_temp_module())
+            parent_path = temp_module_path()
 
             ex = :(import PackageModule.Issue2)
             expected = :(import $(parent_path...).TestPackage.Issue2)

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, temp_module_path, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage, can_import_in_caller, overwrite_imported_symbols
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, temp_module_path, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage, can_import_in_caller, overwrite_imported_symbols, has_ancestor_module
 using Test
 
 import Pkg
@@ -424,4 +424,17 @@ mktempdir() do tmpdir
         m = get_target_module(dict)
         @test isdefined(m, :a)
     end
+end
+
+# We test has_ancestor_module
+@testset "has_ancestor_module" begin
+    m = Main
+    for path_name in (:Test1, :Test2, :Test3)
+        m = Core.eval(m, :(module $path_name end))
+    end
+    @test has_ancestor_module(m, :Test1) # It has an ancestor called :Test1
+    @test !has_ancestor_module(m, :Test1; only_rootmodule = true) # It has an ancestor called :Test1, but it's not the root module (the one which is the parent of itself, i.e. Main in this example)
+    @test has_ancestor_module(m, :Main; only_rootmodule = true) # It has an ancestor Main which is the root
+    @test has_ancestor_module(m, (:Test2, :Test4)) # it works with either of the elements provided
+    @test !has_ancestor_module(m, (:Test5, :Test4)) # it works with either of the elements provided
 end

--- a/test/frompackage/basics.jl
+++ b/test/frompackage/basics.jl
@@ -1,4 +1,4 @@
-import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, fromparent_module, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage
+import PlutoDevMacros.FromPackage: process_outside_pluto!, load_module_in_caller, modname_path, parseinput, get_package_data, @fromparent, _combined, process_skiplines!, get_temp_module, LineNumberRange, parse_skipline, extract_module_expression, _inrange, filterednames, reconstruct_import_expr, extract_import_args, extract_raw_str, @frompackage, update_stored_module, get_target_module, frompackage, FromPackage, can_import_in_caller, overwrite_imported_symbols
 using Test
 
 import Pkg
@@ -102,11 +102,12 @@ end
 
 @testset "Include using names" begin
     target_dir = abspath(@__DIR__, "../TestUsingNames/")
+    caller_module = Core.eval(Main, :(module $(gensym(:TestUsingNames)) end))
     function f(target)
         target_file = joinpath(target_dir, target * "#==#00000000-0000-0000-0000-000000000000")
         dict = get_package_data(target_file)
         # Load the module
-        load_module_in_caller(dict, Main)
+        load_module_in_caller(dict, caller_module)
         return dict
     end
     function has_symbol(symbol, ex::Expr)
@@ -122,30 +123,30 @@ end
     dict = f(target)
     invalid(ex) = nothing === process_outside_pluto!(deepcopy(ex), dict)
     # Test that this only works with catchall
-    @test_throws "You can only use @exclude_using" parseinput(:(@exclude_using import Downloads), dict)
+    @test_throws "You can only use @exclude_using" parseinput(:(@exclude_using import Downloads), dict; caller_module)
     # Test that it throws with ill-formed expression
-    @test_throws "You can only use @exclude_using" parseinput(:(@exclude_using), dict)
+    @test_throws "You can only use @exclude_using" parseinput(:(@exclude_using), dict; caller_module)
     # Test the deprecation warning
-    @test_logs (:warn, r"Use `@exclude_using`") parseinput(:(@include_using import *), dict)
+    @test_logs (:warn, r"Use `@exclude_using`") parseinput(:(@include_using import *), dict; caller_module)
     # Test unsupported expression
-    @test_throws "The provided input expression is not supported" parseinput(:(@asd import *), dict)
+    @test_throws "The provided input expression is not supported" parseinput(:(@asd import *), dict; caller_module)
 
     # Test that even with the @exclude_using macro in front the expression is filtered out outside Pluo
     @test invalid(:(@exclude_using import *))
     # Test that the names are extracted correctly
-    ex = parseinput(:(import *), dict)
+    ex = parseinput(:(import *), dict; caller_module)
     @test has_symbol(:domath, ex)
-    ex = parseinput(:(@exclude_using import *), dict)
+    ex = parseinput(:(@exclude_using import *), dict; caller_module)
     @test !has_symbol(:domath, ex)
 
     # Test2 - test2.jl
     target = "src/test2.jl"
     dict = f(target)
     # Test that the names are extracted correctly
-    ex = parseinput(:(import *), dict)
+    ex = parseinput(:(import *), dict; caller_module)
     @test has_symbol(:test1, ex) # test1 is exported by Module Test1
     @test has_symbol(:base64encode, ex) # test1 is exported by Module Base64
-    ex = parseinput(:(@exclude_using import *), dict)
+    ex = parseinput(:(@exclude_using import *), dict; caller_module)
     @test !has_symbol(:test1, ex)
     @test !has_symbol(:base64encode, ex)
 
@@ -153,18 +154,18 @@ end
     target = "src/test3.jl"
     dict = f(target)
     # Test that the names are extracted correctly, :top_level_func is exported by TestUsingNames
-    ex = parseinput(:(import *), dict)
+    ex = parseinput(:(import *), dict; caller_module)
     @test has_symbol(:top_level_func, ex)
-    ex = parseinput(:(@exclude_using import *), dict)
+    ex = parseinput(:(@exclude_using import *), dict; caller_module)
     @test !has_symbol(:top_level_func, ex)
 
     # Test from a file outside the package
     target = ""
     dict = f(target)
     # Test that the names are extracted correctly, :base64encode is exported by Base64
-    ex = parseinput(:(import *), dict)
+    ex = parseinput(:(import *), dict; caller_module)
     @test has_symbol(:base64encode, ex)
-    ex = parseinput(:(@exclude_using import *), dict)
+    ex = parseinput(:(@exclude_using import *), dict; caller_module)
     @test !has_symbol(:base64encode, ex)
 
     # We test the new skipping capabilities of `filterednames`
@@ -172,26 +173,28 @@ end
     target_mod = update_stored_module(dict)
     m = Module(gensym())
     m.top_level_func = target_mod.top_level_func
-    @test :top_level_func ∉ filterednames(target_mod, m; package_dict=dict)
-    # We now overwrite the module to mimic reloading the macro
-    package_dict = f(target)
-    new_mod = get_target_module(package_dict)
-    @test :top_level_func ∈ filterednames(new_mod, m; package_dict)
+    @test :top_level_func ∉ filterednames(target_mod; caller_module =  m)
+    # We test that it will be imported in a new module without clash
+    @test :top_level_func ∈ filterednames(target_mod; caller_module =  Module(gensym()))
+    # We test that it will also be imported with clash if the name was explicitly imported before. It will still throw as there is already a variable with that name defined in the caller but the filterins should not exclude it
+    overwrite_imported_symbols([:top_level_func])
+    @test :top_level_func ∈ filterednames(target_mod; caller_module = m)
+
     # We test the warning if we are trying to overwrite something we didn't put
-    Core.eval(m, :(voila() = 5))
-    Core.eval(new_mod, :(voila() = 6))
-    @test_logs (:warn, r"is already defined in the caller module") filterednames(new_mod, m; package_dict, explicit_names=Set([:voila]))
+    overwrite_imported_symbols([])
+    @test_logs (:warn, r"is already present in the caller module") filterednames(target_mod; caller_module = m)
 end
 
 
 @testset "Inside Pluto" begin
     @testset "Input Parsing" begin
         @testset "target included in Package" begin
-            dict = load_module_in_caller(inpackage_target, Main)
-            f(ex) = parseinput(deepcopy(ex), dict)
+            caller_module = Module(gensym())
+            dict = load_module_in_caller(inpackage_target, caller_module)
+            f(ex) = parseinput(deepcopy(ex), dict; caller_module)
 
 
-            parent_path = modname_path(fromparent_module[])
+            parent_path = modname_path(get_temp_module())
             # FromDeps imports
             ex = :(using >.BenchmarkTools)
 
@@ -213,12 +216,12 @@ end
             # Test indirect import
             indirect_id = Base.PkgId(Base.UUID("682c06a0-de6a-54ab-a142-c8b1cf79cde6"), "JSON")
             # This will load Tricks inside _DepsImports_
-            _ex = parseinput(:(using >.JSON), dict)
+            _ex = f(:(using >.JSON))
             # We now test that Tricks is loaded in DepsImports
             @test LoadedModules.JSON === Base.maybe_root_module(indirect_id)
 
             # We test that trying to load a package that is not a dependency throws an error saying so
-            @test_throws "The package DataFrames was not" parseinput(:(using >.DataFrames), dict)
+            @test_throws "The package DataFrames was not" f(:(using >.DataFrames))
 
             # FromPackage imports
             ex = :(import TestPackage)
@@ -258,17 +261,18 @@ end
             @test expected == f(ex)
         end
         @testset "target not included in Package" begin
-            dict = load_module_in_caller(inpluto_caller, Main)
-            f(ex) = parseinput(deepcopy(ex), dict)
-            parent_path = modname_path(fromparent_module[])
+            caller_module = Module(gensym())
+            dict = load_module_in_caller(inpluto_caller, caller_module)
+            f(ex) = parseinput(deepcopy(ex), dict; caller_module)
+            parent_path = modname_path(get_temp_module())
 
             ex = :(import PackageModule.Issue2)
             expected = :(import $(parent_path...).TestPackage.Issue2)
             @test expected == f(ex)
 
             ex = :(@exclude_using import *)
-            expected = let _mod = fromparent_module[].TestPackage
-                imported_names = filterednames(_mod; all=true, imported=true)
+            expected = let _mod = get_temp_module().TestPackage
+                imported_names = filterednames(_mod; all=true, imported=true, caller_module)
                 importednames_exprs = map(n -> Expr(:., n), imported_names)
                 modname_expr = Expr(:., vcat(parent_path, :TestPackage)...)
                 reconstruct_import_expr(modname_expr, importednames_exprs)

--- a/test/frompackage/with_pluto_session.jl
+++ b/test/frompackage/with_pluto_session.jl
@@ -108,9 +108,21 @@ srcdir = joinpath(@__DIR__, "../TestUsingNames/src/")
     for filename in ["test_notebook1.jl", "test_notebook2.jl"]
         path = abspath(srcdir, "..", filename)
         nb = SessionActions.open(ss, path; run_async=false)
+        # We test that no errors are present
         for cell in nb.cells
             @test noerror(cell)
         end
+        # We extract the rand_variable value
+        first_value = eval_in_nb((ss, nb), :rand_variable)
+        # We rerun the second cell, containing the `@fromparent` call
+        update_run!(ss, nb, nb.cells[2])
+        # We check again that no errors arose
+        for cell in nb.cells
+            @test noerror(cell)
+        end
+        # We check that the rand_variable value changed
+        second_value = eval_in_nb((ss, nb), :rand_variable)
+        @test first_value != second_value
         SessionActions.shutdown(ss, nb)
     end
 end


### PR DESCRIPTION
This PR addresses a bu that was introduced in #51 to filter out names in catch-all statements.
It fixes #59 and also has some small simplification in the code base.

Anyhow a rewrite of the package internals to further simplify the codebase will happen in a next PR